### PR TITLE
Add Chatterbox TTS support with multi-engine architecture

### DIFF
--- a/engines/__init__.py
+++ b/engines/__init__.py
@@ -1,0 +1,4 @@
+from .coqui_engine import CoquiEngine
+from .chatterbox_engine import ChatterboxEngine
+
+__all__ = ["CoquiEngine", "ChatterboxEngine"]

--- a/engines/chatterbox_engine.py
+++ b/engines/chatterbox_engine.py
@@ -1,0 +1,168 @@
+import os
+from typing import Tuple, Dict, Any, Optional, List, Literal
+import numpy as np
+import logging
+
+from tts_engine_base import TTSEngineBase
+
+logger = logging.getLogger("voice_cloner.chatterbox")
+
+ChatterboxVariant = Literal["turbo", "standard"]
+
+
+class ChatterboxEngine(TTSEngineBase):
+    """TTS engine using Chatterbox by Resemble AI."""
+
+    # Languages supported by multilingual features (when available)
+    SUPPORTED_LANGUAGES = ["en"]  # Base Chatterbox is English-focused
+
+    # Paralinguistic tags supported by Turbo variant
+    PARALINGUISTIC_TAGS = ["laugh", "chuckle", "cough", "sigh", "gasp", "yawn"]
+
+    def __init__(
+        self,
+        speaker_wav: str,
+        device: Optional[str] = None,
+        variant: ChatterboxVariant = "turbo"
+    ):
+        super().__init__(speaker_wav, device)
+        self.variant = variant
+        self._model = None  # Lazy loading
+        self._sample_rate = None
+
+    @property
+    def model(self):
+        """Lazy load model on first use."""
+        if self._model is None:
+            logger.info(f"Loading Chatterbox {self.variant} model...")
+            try:
+                from chatterbox.tts import ChatterboxTTS
+                self._model = ChatterboxTTS.from_pretrained(device=self.device)
+                self._sample_rate = self._model.sr
+                logger.info(f"Chatterbox {self.variant} model loaded successfully")
+            except ImportError as e:
+                logger.error(
+                    "chatterbox-tts package not installed. "
+                    "Install with: pip install chatterbox-tts"
+                )
+                raise ImportError(
+                    "chatterbox-tts package required. Install with: pip install chatterbox-tts"
+                ) from e
+        return self._model
+
+    @property
+    def sample_rate(self) -> int:
+        """Get the model's sample rate."""
+        if self._sample_rate is None:
+            _ = self.model  # Trigger lazy load
+        return self._sample_rate
+
+    def generate(
+        self,
+        text: str,
+        language: str = "en",
+        cfg_weight: float = 0.5,
+        exaggeration: float = 0.5,
+        **kwargs
+    ) -> Tuple[np.ndarray, int]:
+        """
+        Generate audio using Chatterbox.
+
+        Args:
+            text: Text to synthesize. For Turbo, can include tags like [laugh].
+            language: Language code (primarily "en" for base models).
+            cfg_weight: CFG weight (0.0-1.0). Lower values = better pacing for fast speakers.
+            exaggeration: Expressiveness (0.0-1.5). Higher = more dramatic.
+
+        Returns:
+            Tuple of (audio_data, sample_rate)
+        """
+        # Validate reference audio exists
+        if not os.path.exists(self.speaker_wav):
+            raise FileNotFoundError(f"Speaker reference file not found: {self.speaker_wav}")
+
+        # Generate audio
+        wav_tensor = self.model.generate(
+            text,
+            audio_prompt_path=self.speaker_wav,
+            cfg_weight=cfg_weight,
+            exaggeration=exaggeration,
+        )
+
+        # Convert tensor to numpy array
+        audio_data = wav_tensor.squeeze().cpu().numpy().astype(np.float32)
+
+        return audio_data, self.sample_rate
+
+    def get_supported_parameters(self) -> Dict[str, Dict[str, Any]]:
+        params = {
+            "cfg_weight": {
+                "type": float,
+                "default": 0.5,
+                "description": "CFG weight - controls text adherence (0.0-1.0). Lower for fast speakers.",
+                "min": 0.0,
+                "max": 1.0
+            },
+            "exaggeration": {
+                "type": float,
+                "default": 0.5,
+                "description": "Expressiveness level (0.0-1.5). Higher = more dramatic.",
+                "min": 0.0,
+                "max": 1.5
+            }
+        }
+        return params
+
+    @property
+    def name(self) -> str:
+        variant_names = {
+            "turbo": "Chatterbox Turbo (350M)",
+            "standard": "Chatterbox Standard (500M)"
+        }
+        return variant_names.get(self.variant, "Chatterbox")
+
+    @property
+    def supports_languages(self) -> List[str]:
+        return self.SUPPORTED_LANGUAGES
+
+    @property
+    def supports_paralinguistic_tags(self) -> bool:
+        """Check if this variant supports paralinguistic tags."""
+        return self.variant == "turbo"
+
+    def get_paralinguistic_tags(self) -> List[str]:
+        """Get list of supported paralinguistic tags for Turbo variant."""
+        if self.supports_paralinguistic_tags:
+            return self.PARALINGUISTIC_TAGS
+        return []
+
+    def validate_text(self, text: str) -> Tuple[bool, str]:
+        """
+        Validate text for this engine variant.
+
+        Returns:
+            Tuple of (is_valid, message)
+        """
+        import re
+
+        if not text.strip():
+            return False, "Text cannot be empty"
+
+        # Check for paralinguistic tags in non-Turbo variants
+        tags_found = re.findall(r'\[(\w+)\]', text)
+        if tags_found and not self.supports_paralinguistic_tags:
+            return False, (
+                f"Paralinguistic tags {tags_found} are only supported in Turbo variant. "
+                "Switch to Chatterbox Turbo or remove the tags."
+            )
+
+        # Validate tags are recognized
+        if tags_found and self.supports_paralinguistic_tags:
+            invalid_tags = [t for t in tags_found if t not in self.PARALINGUISTIC_TAGS]
+            if invalid_tags:
+                return False, (
+                    f"Unknown tags: {invalid_tags}. "
+                    f"Supported: {self.PARALINGUISTIC_TAGS}"
+                )
+
+        return True, "OK"

--- a/engines/coqui_engine.py
+++ b/engines/coqui_engine.py
@@ -1,0 +1,119 @@
+import os
+import tempfile
+from typing import Tuple, Dict, Any, Optional, List
+import numpy as np
+import soundfile as sf
+import logging
+
+from tts_engine_base import TTSEngineBase
+
+logger = logging.getLogger("voice_cloner.coqui")
+
+
+def _ensure_mono(audio_data: np.ndarray) -> np.ndarray:
+    """Ensure audio is mono (1D array)."""
+    if len(audio_data.shape) > 1:
+        return audio_data.mean(axis=1)
+    return audio_data
+
+
+class CoquiEngine(TTSEngineBase):
+    """TTS engine using Coqui TTS (XTTS v2)."""
+
+    SUPPORTED_LANGUAGES = ["en", "es", "fr", "de", "it", "pt", "pl", "tr", "ru", "nl", "cs", "ar", "zh", "ja", "hu", "ko"]
+
+    def __init__(
+        self,
+        speaker_wav: str,
+        device: Optional[str] = None,
+        model_name: str = "tts_models/multilingual/multi-dataset/xtts_v2"
+    ):
+        super().__init__(speaker_wav, device)
+        self.model_name = model_name
+        self._tts = None  # Lazy loading
+
+    @property
+    def tts(self):
+        """Lazy load TTS model on first use."""
+        if self._tts is None:
+            from TTS.api import TTS
+            logger.info(f"Loading Coqui TTS model: {self.model_name}")
+            self._tts = TTS(
+                model_name=self.model_name,
+                progress_bar=False,
+                gpu=(self.device == "cuda")
+            )
+            logger.info("Coqui TTS model loaded successfully")
+        return self._tts
+
+    def generate(
+        self,
+        text: str,
+        language: str = "en",
+        temperature: float = 0.7,
+        gpt_cond_len: int = 128,
+        **kwargs
+    ) -> Tuple[np.ndarray, int]:
+        """
+        Generate audio using Coqui TTS.
+
+        Args:
+            text: Text to synthesize.
+            language: Language code.
+            temperature: Sampling temperature (0.1-1.0).
+            gpt_cond_len: GPT conditioning length.
+
+        Returns:
+            Tuple of (audio_data, sample_rate)
+        """
+        # Create temp file for output using mkstemp for better cross-platform support
+        fd, temp_path = tempfile.mkstemp(suffix=".wav")
+        os.close(fd)  # Close file descriptor immediately
+
+        try:
+            self.tts.tts_to_file(
+                text=text,
+                speaker_wav=self.speaker_wav,
+                file_path=temp_path,
+                language=language,
+                gpt_cond_len=gpt_cond_len,
+                temperature=temperature,
+            )
+            audio_data, sample_rate = sf.read(temp_path)
+            audio_data = _ensure_mono(audio_data)
+            return audio_data.astype(np.float32), sample_rate
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+    def get_supported_parameters(self) -> Dict[str, Dict[str, Any]]:
+        return {
+            "language": {
+                "type": str,
+                "default": "en",
+                "description": "Language code (en, es, fr, de, etc.)",
+                "options": self.SUPPORTED_LANGUAGES
+            },
+            "temperature": {
+                "type": float,
+                "default": 0.7,
+                "description": "Sampling temperature (0.1-1.0)",
+                "min": 0.1,
+                "max": 1.0
+            },
+            "gpt_cond_len": {
+                "type": int,
+                "default": 128,
+                "description": "GPT conditioning length",
+                "min": 32,
+                "max": 256
+            }
+        }
+
+    @property
+    def name(self) -> str:
+        return "Coqui XTTS v2"
+
+    @property
+    def supports_languages(self) -> List[str]:
+        return self.SUPPORTED_LANGUAGES

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -1,0 +1,3 @@
+from .engine_controls import EngineControlsBase, CoquiControls, ChatterboxControls, EngineControlsFactory
+
+__all__ = ["EngineControlsBase", "CoquiControls", "ChatterboxControls", "EngineControlsFactory"]

--- a/gui/engine_controls.py
+++ b/gui/engine_controls.py
@@ -1,0 +1,194 @@
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QSlider,
+    QComboBox, QPushButton, QGroupBox, QMessageBox
+)
+from PySide6.QtCore import Qt, Signal
+from typing import Dict, Any
+
+
+class EngineControlsBase(QWidget):
+    """Base class for engine-specific control widgets."""
+
+    parameters_changed = Signal(dict)
+
+    def get_parameters(self) -> Dict[str, Any]:
+        """Return current parameter values."""
+        raise NotImplementedError
+
+
+class CoquiControls(EngineControlsBase):
+    """Control widget for Coqui XTTS v2 engine."""
+
+    LANGUAGES = [
+        ("English", "en"),
+        ("Spanish", "es"),
+        ("French", "fr"),
+        ("German", "de"),
+        ("Italian", "it"),
+        ("Portuguese", "pt"),
+        ("Polish", "pl"),
+        ("Turkish", "tr"),
+        ("Russian", "ru"),
+        ("Dutch", "nl"),
+        ("Czech", "cs"),
+        ("Arabic", "ar"),
+        ("Chinese", "zh"),
+        ("Japanese", "ja"),
+        ("Hungarian", "hu"),
+        ("Korean", "ko"),
+    ]
+
+    def __init__(self):
+        super().__init__()
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        # Language selector
+        lang_layout = QHBoxLayout()
+        lang_layout.addWidget(QLabel("Language:"))
+        self.lang_combo = QComboBox()
+        for display_name, code in self.LANGUAGES:
+            self.lang_combo.addItem(display_name, code)
+        self.lang_combo.currentIndexChanged.connect(self._on_param_changed)
+        lang_layout.addWidget(self.lang_combo)
+        lang_layout.addStretch()
+        layout.addLayout(lang_layout)
+
+        # Temperature slider
+        temp_group = QGroupBox("Temperature")
+        temp_layout = QHBoxLayout()
+        self.temp_slider = QSlider(Qt.Horizontal)
+        self.temp_slider.setRange(10, 100)  # 0.1 to 1.0
+        self.temp_slider.setValue(70)
+        self.temp_slider.valueChanged.connect(self._on_param_changed)
+        self.temp_label = QLabel("0.70")
+        self.temp_slider.valueChanged.connect(
+            lambda v: self.temp_label.setText(f"{v/100:.2f}")
+        )
+        temp_layout.addWidget(self.temp_slider)
+        temp_layout.addWidget(self.temp_label)
+        temp_group.setLayout(temp_layout)
+        layout.addWidget(temp_group)
+
+        self.setLayout(layout)
+
+    def _on_param_changed(self):
+        self.parameters_changed.emit(self.get_parameters())
+
+    def get_parameters(self) -> Dict[str, Any]:
+        return {
+            "language": self.lang_combo.currentData(),
+            "temperature": self.temp_slider.value() / 100.0,
+        }
+
+
+class ChatterboxControls(EngineControlsBase):
+    """Control widget for Chatterbox engine."""
+
+    PARALINGUISTIC_TAGS = ["laugh", "chuckle", "cough", "sigh", "gasp", "yawn"]
+
+    def __init__(self, variant: str = "turbo"):
+        super().__init__()
+        self.variant = variant
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        # CFG Weight slider
+        cfg_group = QGroupBox("CFG Weight (text adherence)")
+        cfg_layout = QHBoxLayout()
+        self.cfg_slider = QSlider(Qt.Horizontal)
+        self.cfg_slider.setRange(0, 100)  # 0.0 to 1.0
+        self.cfg_slider.setValue(50)
+        self.cfg_slider.valueChanged.connect(self._on_param_changed)
+        self.cfg_label = QLabel("0.50")
+        self.cfg_slider.valueChanged.connect(
+            lambda v: self.cfg_label.setText(f"{v/100:.2f}")
+        )
+        cfg_layout.addWidget(QLabel("Less"))
+        cfg_layout.addWidget(self.cfg_slider)
+        cfg_layout.addWidget(QLabel("More"))
+        cfg_layout.addWidget(self.cfg_label)
+        cfg_group.setLayout(cfg_layout)
+        layout.addWidget(cfg_group)
+
+        # Exaggeration slider
+        exag_group = QGroupBox("Exaggeration (expressiveness)")
+        exag_layout = QHBoxLayout()
+        self.exag_slider = QSlider(Qt.Horizontal)
+        self.exag_slider.setRange(0, 150)  # 0.0 to 1.5
+        self.exag_slider.setValue(50)
+        self.exag_slider.valueChanged.connect(self._on_param_changed)
+        self.exag_label = QLabel("0.50")
+        self.exag_slider.valueChanged.connect(
+            lambda v: self.exag_label.setText(f"{v/100:.2f}")
+        )
+        exag_layout.addWidget(QLabel("Subtle"))
+        exag_layout.addWidget(self.exag_slider)
+        exag_layout.addWidget(QLabel("Dramatic"))
+        exag_layout.addWidget(self.exag_label)
+        exag_group.setLayout(exag_layout)
+        layout.addWidget(exag_group)
+
+        # Paralinguistic tags help (Turbo only)
+        if self.variant == "turbo":
+            tag_layout = QHBoxLayout()
+            self.tag_button = QPushButton("Paralinguistic Tags Help")
+            self.tag_button.clicked.connect(self._show_tags_help)
+            tag_layout.addWidget(self.tag_button)
+            tag_layout.addStretch()
+            layout.addLayout(tag_layout)
+
+        self.setLayout(layout)
+
+    def _on_param_changed(self):
+        self.parameters_changed.emit(self.get_parameters())
+
+    def _show_tags_help(self):
+        tags_text = ", ".join([f"[{tag}]" for tag in self.PARALINGUISTIC_TAGS])
+        QMessageBox.information(
+            self,
+            "Paralinguistic Tags",
+            f"Chatterbox Turbo supports these expressive tags:\n\n"
+            f"{tags_text}\n\n"
+            f"Example usage:\n"
+            f"'That's hilarious [laugh]!'\n"
+            f"'*sighs* [sigh] I can't believe this...'\n\n"
+            f"Place tags where you want the sound to occur."
+        )
+
+    def get_parameters(self) -> Dict[str, Any]:
+        return {
+            "cfg_weight": self.cfg_slider.value() / 100.0,
+            "exaggeration": self.exag_slider.value() / 100.0,
+        }
+
+
+class EngineControlsFactory:
+    """Factory for creating engine-specific control widgets."""
+
+    @staticmethod
+    def create(engine_name: str) -> EngineControlsBase:
+        """
+        Create control widget for the specified engine.
+
+        Args:
+            engine_name: Engine identifier (e.g., "coqui", "chatterbox-turbo")
+
+        Returns:
+            EngineControlsBase widget instance
+        """
+        if engine_name == "coqui":
+            return CoquiControls()
+        elif engine_name == "chatterbox-turbo":
+            return ChatterboxControls(variant="turbo")
+        elif engine_name == "chatterbox-standard":
+            return ChatterboxControls(variant="standard")
+        else:
+            # Return empty widget for unknown engines
+            return EngineControlsBase()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,11 @@ TTS>=0.22.0
 sounddevice>=0.5.1
 soundfile>=0.13.0
 PySide6>=6.4.0
+rich>=13.0.0
+pygame>=2.5.0
+numpy>=1.24.0
+
+# Optional: Chatterbox TTS support
+# Uncomment the following line to enable Chatterbox engines
+# Note: Requires Python 3.11 for best compatibility
+# chatterbox-tts>=0.1.0

--- a/test_chatterbox.py
+++ b/test_chatterbox.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Test script for Chatterbox TTS engine."""
+
+import os
+import sys
+
+# Add project root to path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from voice_cloner import VoiceCloner
+
+def main():
+    # Use a voice sample
+    voice_sample = "./voice-samples/geralt_original.mp3"
+    output_file = "./output-examples/chatterbox_test.wav"
+
+    print(f"Testing Chatterbox TTS with voice sample: {voice_sample}")
+    print("-" * 50)
+
+    # Create VoiceCloner with Chatterbox Turbo
+    print("Initializing VoiceCloner with Chatterbox Turbo...")
+    cloner = VoiceCloner.from_chatterbox(
+        speaker_wav=voice_sample,
+        variant="turbo"
+    )
+
+    # Generate speech
+    text = "Hello, I am Geralt of Rivia. I hunt monsters for coin."
+    print(f"Generating speech for: '{text}'")
+    print("-" * 50)
+
+    cloner.say(
+        text,
+        play_audio=False,  # Don't play, just save
+        save_audio=True,
+        output_file=output_file,
+        cfg_weight=0.5,
+        exaggeration=0.5
+    )
+
+    print(f"\nDone! Audio saved to: {output_file}")
+
+    # Check file was created
+    if os.path.exists(output_file):
+        size = os.path.getsize(output_file)
+        print(f"File size: {size / 1024:.1f} KB")
+    else:
+        print("ERROR: Output file was not created!")
+        return 1
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tts_engine_base.py
+++ b/tts_engine_base.py
@@ -1,0 +1,58 @@
+from abc import ABC, abstractmethod
+from typing import Tuple, Dict, Any, Optional
+import numpy as np
+import torch
+
+
+class TTSEngineBase(ABC):
+    """Abstract base class for TTS engines."""
+
+    def __init__(self, speaker_wav: str, device: Optional[str] = None):
+        self.speaker_wav = speaker_wav
+        self.device = device or self._default_device()
+
+    @abstractmethod
+    def generate(
+        self,
+        text: str,
+        language: str = "en",
+        **kwargs
+    ) -> Tuple[np.ndarray, int]:
+        """
+        Generate audio from text.
+
+        Args:
+            text: The text to convert to speech.
+            language: Language code (e.g., "en", "fr", "de").
+            **kwargs: Engine-specific parameters.
+
+        Returns:
+            Tuple of (audio_data: np.ndarray, sample_rate: int)
+        """
+        pass
+
+    @abstractmethod
+    def get_supported_parameters(self) -> Dict[str, Dict[str, Any]]:
+        """
+        Return supported parameters with their metadata.
+
+        Returns:
+            Dict mapping param_name -> {"type": type, "default": value, "description": str}
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable engine name."""
+        pass
+
+    @property
+    @abstractmethod
+    def supports_languages(self) -> list:
+        """List of supported language codes."""
+        pass
+
+    @staticmethod
+    def _default_device() -> str:
+        return "cuda" if torch.cuda.is_available() else "cpu"

--- a/tts_factory.py
+++ b/tts_factory.py
@@ -1,0 +1,149 @@
+from typing import Dict, Type, Optional, List
+import logging
+
+from tts_engine_base import TTSEngineBase
+
+logger = logging.getLogger("voice_cloner.factory")
+
+
+class TTSFactory:
+    """Factory for creating TTS engine instances."""
+
+    # Engine registry: name -> (engine_class, variant_kwargs)
+    _registry: Dict[str, tuple] = {}
+
+    # Engine display names for UI
+    _display_names: Dict[str, str] = {}
+
+    @classmethod
+    def register(
+        cls,
+        name: str,
+        engine_class: Type[TTSEngineBase],
+        display_name: str,
+        **default_kwargs
+    ):
+        """
+        Register an engine class.
+
+        Args:
+            name: Unique identifier for the engine (e.g., "chatterbox-turbo")
+            engine_class: The engine class to instantiate
+            display_name: Human-readable name for UI
+            **default_kwargs: Default kwargs passed to engine constructor
+        """
+        cls._registry[name] = (engine_class, default_kwargs)
+        cls._display_names[name] = display_name
+        logger.debug(f"Registered TTS engine: {name}")
+
+    @classmethod
+    def create(
+        cls,
+        engine_name: str,
+        speaker_wav: str,
+        device: Optional[str] = None,
+        **engine_kwargs
+    ) -> TTSEngineBase:
+        """
+        Create an engine instance.
+
+        Args:
+            engine_name: Registered engine name
+            speaker_wav: Path to speaker reference audio
+            device: Device to use ("cuda" or "cpu")
+            **engine_kwargs: Additional engine-specific parameters
+
+        Returns:
+            Configured TTSEngineBase instance
+        """
+        if engine_name not in cls._registry:
+            available = list(cls._registry.keys())
+            raise ValueError(
+                f"Unknown engine: '{engine_name}'. "
+                f"Available engines: {available}"
+            )
+
+        engine_class, default_kwargs = cls._registry[engine_name]
+
+        # Merge default kwargs with provided kwargs
+        merged_kwargs = {**default_kwargs, **engine_kwargs}
+
+        logger.info(f"Creating TTS engine: {engine_name}")
+        return engine_class(
+            speaker_wav=speaker_wav,
+            device=device,
+            **merged_kwargs
+        )
+
+    @classmethod
+    def available_engines(cls) -> List[str]:
+        """Get list of registered engine names."""
+        return list(cls._registry.keys())
+
+    @classmethod
+    def get_display_name(cls, engine_name: str) -> str:
+        """Get human-readable display name for an engine."""
+        return cls._display_names.get(engine_name, engine_name)
+
+    @classmethod
+    def get_engine_info(cls) -> Dict[str, str]:
+        """Get dict of engine_name -> display_name for all engines."""
+        return cls._display_names.copy()
+
+    @classmethod
+    def is_available(cls, engine_name: str) -> bool:
+        """Check if an engine's dependencies are installed."""
+        if engine_name not in cls._registry:
+            return False
+
+        engine_class, _ = cls._registry[engine_name]
+
+        # Check for required imports
+        try:
+            if "coqui" in engine_name.lower():
+                import TTS  # noqa: F401
+            elif "chatterbox" in engine_name.lower():
+                import chatterbox  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+
+def _register_default_engines():
+    """Register the default TTS engines."""
+    # Register Coqui engine
+    try:
+        from engines.coqui_engine import CoquiEngine
+        TTSFactory.register(
+            name="coqui",
+            engine_class=CoquiEngine,
+            display_name="Coqui XTTS v2"
+        )
+    except ImportError as e:
+        logger.warning(f"Coqui engine not available: {e}")
+
+    # Register Chatterbox engines
+    try:
+        from engines.chatterbox_engine import ChatterboxEngine
+
+        # Chatterbox Turbo (fast, supports paralinguistic tags)
+        TTSFactory.register(
+            name="chatterbox-turbo",
+            engine_class=ChatterboxEngine,
+            display_name="Chatterbox Turbo (350M)",
+            variant="turbo"
+        )
+
+        # Chatterbox Standard (higher quality)
+        TTSFactory.register(
+            name="chatterbox-standard",
+            engine_class=ChatterboxEngine,
+            display_name="Chatterbox Standard (500M)",
+            variant="standard"
+        )
+    except ImportError as e:
+        logger.warning(f"Chatterbox engines not available: {e}")
+
+
+# Auto-register engines on module import
+_register_default_engines()

--- a/vcloner.py
+++ b/vcloner.py
@@ -4,6 +4,7 @@ import logging
 from rich.logging import RichHandler
 from rich.console import Console
 from voice_cloner import VoiceCloner
+from tts_factory import TTSFactory
 
 # Configure logging with Rich for a better terminal experience
 logging.basicConfig(
@@ -15,36 +16,153 @@ logger = logging.getLogger("voice_cloner")
 
 console = Console()
 
-def main():
-    parser = argparse.ArgumentParser(description="Clone a voice and generate speech.")
-    parser.add_argument("-i", "--input_voice", required=True, help="Path to the original voice WAV/MP3 file (REQUIRED).")
-    parser.add_argument("-t", "--text", required=True, help="Text to be converted to speech (REQUIRED).")
-    parser.add_argument("-o", "--output_file", required=True, help="Path and name of the output audio file (REQUIRED).")
 
-    # Parse arguments with error handling
-    try:
-        args = parser.parse_args()
-    except SystemExit as e:
-        if e.code == 2:  # Code 2 indicates missing or incorrect arguments
-            parser.print_help()
-            return
+def main():
+    # Get available engines for help text
+    available_engines = TTSFactory.available_engines()
+    engines_help = ", ".join(available_engines)
+
+    parser = argparse.ArgumentParser(
+        description="Clone a voice and generate speech using multiple TTS engines.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Using Coqui (default)
+  python vcloner.py -i voice.wav -t "Hello world" -o output.wav
+
+  # Using Chatterbox Turbo (fast)
+  python vcloner.py -i voice.wav -t "Hello world" -o output.wav --engine chatterbox-turbo
+
+  # Using Chatterbox with custom parameters
+  python vcloner.py -i voice.wav -t "That's funny [laugh]!" -o output.wav \\
+      --engine chatterbox-turbo --cfg-weight 0.3 --exaggeration 0.7
+
+  # List available engines
+  python vcloner.py --list-engines
+        """
+    )
+
+    parser.add_argument(
+        "-i", "--input_voice",
+        help="Path to the original voice WAV/MP3 file (REQUIRED for generation)."
+    )
+    parser.add_argument(
+        "-t", "--text",
+        help="Text to be converted to speech (REQUIRED for generation)."
+    )
+    parser.add_argument(
+        "-o", "--output_file",
+        help="Path and name of the output audio file (REQUIRED for generation)."
+    )
+    parser.add_argument(
+        "-e", "--engine",
+        default="coqui",
+        choices=available_engines,
+        help=f"TTS engine to use. Available: {engines_help}. Default: coqui"
+    )
+    parser.add_argument(
+        "-l", "--language",
+        default="en",
+        help="Language code (default: en). For Coqui: en, es, fr, de, etc."
+    )
+
+    # Coqui-specific arguments
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.7,
+        help="Coqui: Sampling temperature (0.1-1.0). Default: 0.7"
+    )
+
+    # Chatterbox-specific arguments
+    parser.add_argument(
+        "--cfg-weight",
+        type=float,
+        default=0.5,
+        help="Chatterbox: CFG weight for text adherence (0.0-1.0). Lower for fast speakers. Default: 0.5"
+    )
+    parser.add_argument(
+        "--exaggeration",
+        type=float,
+        default=0.5,
+        help="Chatterbox: Expressiveness level (0.0-1.5). Higher = more dramatic. Default: 0.5"
+    )
+
+    # Utility arguments
+    parser.add_argument(
+        "--list-engines",
+        action="store_true",
+        help="List available TTS engines and exit."
+    )
+    parser.add_argument(
+        "--no-play",
+        action="store_true",
+        help="Don't play audio after generation."
+    )
+
+    args = parser.parse_args()
+
+    # Handle --list-engines
+    if args.list_engines:
+        console.print("\n[bold]Available TTS Engines:[/bold]\n")
+        engine_info = TTSFactory.get_engine_info()
+        for engine_id, display_name in engine_info.items():
+            available = TTSFactory.is_available(engine_id)
+            status = "[green]installed[/green]" if available else "[red]not installed[/red]"
+            console.print(f"  {engine_id}: {display_name} ({status})")
+        console.print("")
+        return
+
+    # Validate required arguments for generation
+    if not args.input_voice or not args.text or not args.output_file:
+        parser.print_help()
+        console.print("\n[red]Error:[/red] -i, -t, and -o are required for audio generation.")
+        return
 
     # Ensure the directory for the output file exists
     output_dir = os.path.dirname(args.output_file)
-    os.makedirs(output_dir, exist_ok=True)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
 
     try:
-        logger.info(f"[bold cyan] Initializing VoiceCloner with reference voice:[/bold cyan] {args.input_voice}")
-        cloner = VoiceCloner(speaker_wav=args.input_voice)
+        logger.info(f"[bold cyan]Initializing VoiceCloner[/bold cyan]")
+        logger.info(f"  Engine: {args.engine}")
+        logger.info(f"  Reference voice: {args.input_voice}")
 
-        logger.info("[bold green] Generating speech...[/bold green]")
-        cloner.say(args.text, play_audio=True, save_audio=True, output_file=args.output_file)
+        # Build engine-specific kwargs
+        engine_kwargs = {"language": args.language}
 
-        logger.info(f"[bold green] Speech successfully generated and saved to:[/bold green] {args.output_file}")
+        if args.engine == "coqui":
+            engine_kwargs["temperature"] = args.temperature
+        elif "chatterbox" in args.engine:
+            engine_kwargs["cfg_weight"] = args.cfg_weight
+            engine_kwargs["exaggeration"] = args.exaggeration
+
+        # Create cloner
+        cloner = VoiceCloner(
+            speaker_wav=args.input_voice,
+            engine=args.engine
+        )
+
+        logger.info("[bold green]Generating speech...[/bold green]")
+        cloner.say(
+            args.text,
+            play_audio=not args.no_play,
+            save_audio=True,
+            output_file=args.output_file,
+            **engine_kwargs
+        )
+
+        logger.info(f"[bold green]Speech saved to:[/bold green] {args.output_file}")
+
     except FileNotFoundError:
-        logger.error(f"[bold red] Error:[/bold red] Input voice file not found at {args.input_voice}")
+        logger.error(f"[bold red]Error:[/bold red] Input voice file not found: {args.input_voice}")
+    except ImportError as e:
+        logger.error(f"[bold red]Missing dependency:[/bold red] {e}")
+        logger.info("Install required package with: pip install <package-name>")
     except Exception as e:
-        logger.error(f"[bold red] An unexpected error occurred:[/bold red] {e}")
+        logger.error(f"[bold red]Error:[/bold red] {e}")
+
 
 if __name__ == "__main__":
     main()

--- a/voice_cloning_app.py
+++ b/voice_cloning_app.py
@@ -2,27 +2,34 @@ import sys
 import os
 import uuid
 import tempfile
-import subprocess
-import pygame
 from pathlib import Path
-from PySide6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
-                               QHBoxLayout, QLabel, QTextEdit, QPushButton,
-                               QFileDialog, QMessageBox)
+from PySide6.QtWidgets import (
+    QApplication, QMainWindow, QWidget, QVBoxLayout,
+    QHBoxLayout, QLabel, QTextEdit, QPushButton,
+    QFileDialog, QMessageBox, QComboBox, QGroupBox
+)
 from PySide6.QtCore import Qt, QThread, Signal, Slot
 from PySide6.QtGui import QIcon
-from voice_cloner import VoiceCloner  # Your updated cloner
+import pygame
+
+from voice_cloner import VoiceCloner
+from tts_factory import TTSFactory
+from gui.engine_controls import EngineControlsFactory
 
 
 class CloneThread(QThread):
+    """Thread for running TTS generation without blocking the UI."""
+
     finished = Signal(str, str)
     error_occurred = Signal(str)
 
-    def __init__(self, text, voice_path):
+    def __init__(self, text: str, voice_path: str, engine_name: str, engine_params: dict):
         super().__init__()
         self.text = text
         self.voice_path = voice_path
+        self.engine_name = engine_name
+        self.engine_params = engine_params
         self.output_path = None
-        self.voice_cloner = VoiceCloner(speaker_wav=self.voice_path)
 
     def run(self):
         try:
@@ -33,28 +40,79 @@ class CloneThread(QThread):
             # Generate unique filename
             self.output_path = output_dir / f"output_{uuid.uuid4().hex}.wav"
 
-            # Generate audio using the updated VoiceCloner
-            self.voice_cloner.say(self.text, play_audio=False, save_audio=True, output_file=str(self.output_path))
+            # Create VoiceCloner with selected engine
+            voice_cloner = VoiceCloner(
+                speaker_wav=self.voice_path,
+                engine=self.engine_name
+            )
+
+            # Generate audio
+            voice_cloner.say(
+                self.text,
+                play_audio=False,
+                save_audio=True,
+                output_file=str(self.output_path),
+                **self.engine_params
+            )
             self.finished.emit(str(self.output_path), self.text)
         except Exception as e:
             self.error_occurred.emit(str(e))
-        finally:
-            # Clean up voice file if needed
-            if Path(self.voice_path).exists():
-                os.remove(self.voice_path)
 
 
 class VoiceCloningApp(QMainWindow):
+    """Main application window for Voice Cloner."""
+
+    # Map display names to engine identifiers
+    ENGINE_OPTIONS = [
+        ("Coqui XTTS v2 (Multilingual)", "coqui"),
+        ("Chatterbox Turbo (Fast)", "chatterbox-turbo"),
+        ("Chatterbox Standard (High Quality)", "chatterbox-standard"),
+    ]
+
     def __init__(self):
         super().__init__()
         self.current_audio = None
+        self.voice_path = None
+        self.engine_controls = None
+        self.clone_thread = None
+        self._temp_voice_file = None
+
         self.init_ui()
         self.setWindowTitle("VoiceCloner")
-        self.setMinimumSize(600, 400)
+        self.setMinimumSize(650, 550)
         self.setWindowIcon(QIcon(str(Path(__file__).parent / "icon.jpg")))
 
         # Initialize pygame mixer for audio
         pygame.mixer.init()
+
+    def closeEvent(self, event):
+        """Clean up resources when window closes."""
+        # Stop any playing audio
+        pygame.mixer.music.stop()
+        pygame.mixer.quit()
+
+        # Wait for thread to finish
+        if self.clone_thread and self.clone_thread.isRunning():
+            self.clone_thread.quit()
+            self.clone_thread.wait(1000)
+
+        # Clean up temp files
+        self._cleanup_temp_files()
+
+        super().closeEvent(event)
+
+    def _cleanup_temp_files(self):
+        """Clean up temporary files."""
+        if self._temp_voice_file and Path(self._temp_voice_file).exists():
+            try:
+                Path(self._temp_voice_file).unlink()
+            except OSError:
+                pass
+        if self.current_audio and Path(self.current_audio).exists():
+            try:
+                Path(self.current_audio).unlink()
+            except OSError:
+                pass
 
     def init_ui(self):
         main_widget = QWidget()
@@ -62,24 +120,52 @@ class VoiceCloningApp(QMainWindow):
         layout.setContentsMargins(20, 20, 20, 20)
         layout.setSpacing(15)
 
+        # Model selection
+        model_group = QGroupBox("TTS Engine")
+        model_layout = QVBoxLayout()
+
+        engine_row = QHBoxLayout()
+        engine_row.addWidget(QLabel("Engine:"))
+        self.engine_combo = QComboBox()
+        for display_name, engine_id in self.ENGINE_OPTIONS:
+            self.engine_combo.addItem(display_name, engine_id)
+        self.engine_combo.currentIndexChanged.connect(self.on_engine_changed)
+        engine_row.addWidget(self.engine_combo)
+        model_layout.addLayout(engine_row)
+
+        # Container for engine-specific controls
+        self.controls_container = QVBoxLayout()
+        model_layout.addLayout(self.controls_container)
+
+        model_group.setLayout(model_layout)
+        layout.addWidget(model_group)
+
+        # Initialize with first engine's controls
+        self._update_engine_controls("coqui")
+
         # Text input
+        text_group = QGroupBox("Text to Synthesize")
+        text_layout = QVBoxLayout()
         self.text_input = QTextEdit()
         self.text_input.setPlaceholderText("Enter text to generate audio...")
         self.text_input.setAcceptRichText(False)
         self.text_input.setMinimumHeight(100)
-        layout.addWidget(QLabel("Input Text"))
-        layout.addWidget(self.text_input)
+        text_layout.addWidget(self.text_input)
+        text_group.setLayout(text_layout)
+        layout.addWidget(text_group)
 
         # Voice file selection
+        voice_group = QGroupBox("Voice Reference")
+        voice_layout = QHBoxLayout()
+        self.btn_select_voice = QPushButton("Select Voice File")
+        self.btn_select_voice.clicked.connect(self.select_voice_file)
         self.voice_label = QLabel("No voice file selected")
         self.voice_label.setWordWrap(True)
-        self.btn_select_voice = QPushButton("Select Original Voice")
-        self.btn_select_voice.clicked.connect(self.select_voice_file)
-
-        file_selector_layout = QHBoxLayout()
-        file_selector_layout.addWidget(self.btn_select_voice)
-        file_selector_layout.addWidget(self.voice_label)
-        layout.addLayout(file_selector_layout)
+        self.voice_label.setStyleSheet("color: #666;")
+        voice_layout.addWidget(self.btn_select_voice)
+        voice_layout.addWidget(self.voice_label, stretch=1)
+        voice_group.setLayout(voice_layout)
+        layout.addWidget(voice_group)
 
         # Generate button
         self.btn_generate = QPushButton("Generate Audio")
@@ -92,6 +178,9 @@ class VoiceCloningApp(QMainWindow):
                 padding: 12px 24px;
                 font-size: 16px;
                 border-radius: 4px;
+            }
+            QPushButton:hover {
+                background-color: #45a049;
             }
             QPushButton:disabled {
                 background-color: #81C784;
@@ -111,14 +200,32 @@ class VoiceCloningApp(QMainWindow):
 
         result_layout.addWidget(self.btn_play)
         result_layout.addWidget(self.btn_save)
+        result_layout.addStretch()
         layout.addLayout(result_layout)
 
+        layout.addStretch()
         main_widget.setLayout(layout)
         self.setCentralWidget(main_widget)
 
+    def _update_engine_controls(self, engine_name: str):
+        """Update the engine-specific control widgets."""
+        # Remove existing controls
+        if self.engine_controls:
+            self.controls_container.removeWidget(self.engine_controls)
+            self.engine_controls.deleteLater()
+
+        # Create new controls for selected engine
+        self.engine_controls = EngineControlsFactory.create(engine_name)
+        self.controls_container.addWidget(self.engine_controls)
+
+    def on_engine_changed(self, index: int):
+        """Handle engine selection change."""
+        engine_name = self.engine_combo.currentData()
+        self._update_engine_controls(engine_name)
+
     def select_voice_file(self):
         file_dialog = QFileDialog(self)
-        file_dialog.setNameFilter("Audio Files (*.wav *.mp3 *.ogg)")
+        file_dialog.setNameFilter("Audio Files (*.wav *.mp3 *.ogg *.flac)")
         if file_dialog.exec():
             files = file_dialog.selectedFiles()
             if files:
@@ -127,53 +234,95 @@ class VoiceCloningApp(QMainWindow):
                 self.voice_label.setStyleSheet("color: #333;")
 
     def start_cloning(self):
-        if not hasattr(self, 'voice_path'):
-            QMessageBox.warning(self, "Missing Original Voice", "Please select an audio file (.wav, .m3, .ogg)")
+        if not self.voice_path:
+            QMessageBox.warning(
+                self,
+                "Missing Voice Reference",
+                "Please select an audio file (.wav, .mp3, .ogg, .flac) as voice reference."
+            )
             return
 
         text = self.text_input.toPlainText().strip()
         if not text:
-            QMessageBox.warning(self, "Missing Text", "Please enter text to generate audio")
+            QMessageBox.warning(
+                self,
+                "Missing Text",
+                "Please enter text to generate audio."
+            )
             return
+
+        # Check if a thread is already running
+        if self.clone_thread and self.clone_thread.isRunning():
+            QMessageBox.warning(
+                self,
+                "Generation In Progress",
+                "Please wait for the current generation to complete."
+            )
+            return
+
         # Disable UI during processing
         self.btn_generate.setEnabled(False)
-        self.btn_generate.setText("Generating audio ...")
+        self.btn_generate.setText("Generating audio...")
         self.btn_play.hide()
         self.btn_save.hide()
-        # Disable the "Select Voice File" button
         self.btn_select_voice.setEnabled(False)
+        self.engine_combo.setEnabled(False)
+
+        # Get selected engine and parameters
+        engine_name = self.engine_combo.currentData()
+        engine_params = self.engine_controls.get_parameters()
 
         # Create temporary copy of voice file
-        temp_voice = Path(tempfile.gettempdir()) / f"voice_{uuid.uuid4().hex}{Path(self.voice_path).suffix}"
-        temp_voice.write_bytes(Path(self.voice_path).read_bytes())
+        try:
+            temp_voice = Path(tempfile.gettempdir()) / f"voice_{uuid.uuid4().hex}{Path(self.voice_path).suffix}"
+            temp_voice.write_bytes(Path(self.voice_path).read_bytes())
+            self._temp_voice_file = str(temp_voice)
+        except (OSError, PermissionError, MemoryError) as e:
+            self._reset_ui_state()
+            QMessageBox.critical(
+                self,
+                "File Error",
+                f"Cannot read voice file: {e}"
+            )
+            return
 
         # Start cloning thread
-        self.clone_thread = CloneThread(text, str(temp_voice))
+        self.clone_thread = CloneThread(
+            text=text,
+            voice_path=str(temp_voice),
+            engine_name=engine_name,
+            engine_params=engine_params
+        )
         self.clone_thread.finished.connect(self.on_cloning_finished)
         self.clone_thread.error_occurred.connect(self.on_cloning_error)
         self.clone_thread.start()
 
-    def on_cloning_finished(self, output_path, text):
+    def on_cloning_finished(self, output_path: str, text: str):
         self.current_audio = output_path
-        self.btn_generate.setEnabled(True)
-        self.btn_generate.setText("Generate Audio")
+        self._reset_ui_state()
         self.btn_play.show()
         self.btn_save.show()
 
-        # Re-enable the "Select Voice File" button after cloning finishes
-        self.btn_select_voice.setEnabled(True)
-
     @Slot(str)
-    def on_cloning_error(self, message):
+    def on_cloning_error(self, message: str):
+        self._reset_ui_state()
+        QMessageBox.critical(
+            self,
+            "Generation Error",
+            f"Failed to generate audio:\n\n{message}"
+        )
+
+    def _reset_ui_state(self):
+        """Reset UI to normal state after generation."""
         self.btn_generate.setEnabled(True)
         self.btn_generate.setText("Generate Audio")
-        QMessageBox.critical(self, "Error", f"Failed:\n{message}")
-
-        # Re-enable the "Select Voice File" button after cloning error
         self.btn_select_voice.setEnabled(True)
+        self.engine_combo.setEnabled(True)
 
     def play_audio(self):
         if self.current_audio and Path(self.current_audio).exists():
+            # Stop any currently playing audio first
+            pygame.mixer.music.stop()
             pygame.mixer.music.load(self.current_audio)
             pygame.mixer.music.play()
 
@@ -186,8 +335,13 @@ class VoiceCloningApp(QMainWindow):
                 "Wave Files (*.wav)"
             )
             if file_path:
-                Path(self.current_audio).rename(file_path)
-                QMessageBox.information(self, "Saved", "Audio file saved successfully")
+                import shutil
+                shutil.copy2(self.current_audio, file_path)
+                QMessageBox.information(
+                    self,
+                    "Saved",
+                    f"Audio file saved to:\n{file_path}"
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds support for **Chatterbox TTS** by Resemble AI alongside existing Coqui TTS
- Implements a clean **Strategy Pattern** architecture with abstract base class for TTS engines
- Enables easy addition of future TTS engines (Bark, VALL-E, etc.)

### New Engines Supported
| Engine | Parameters | Size | Features |
|--------|-----------|------|----------|
| Coqui XTTS v2 | language, temperature | Default | 16+ languages |
| Chatterbox Turbo | cfg_weight, exaggeration | 350M | Fast, paralinguistic tags `[laugh]`, `[sigh]` |
| Chatterbox Standard | cfg_weight, exaggeration | 500M | Higher quality |

### Changes
- **New files**: `tts_engine_base.py`, `tts_factory.py`, `engines/`, `gui/engine_controls.py`
- **GUI**: Model selector dropdown with dynamic engine-specific controls
- **CLI**: `--engine` argument with `--cfg-weight`, `--exaggeration` for Chatterbox
- **Architecture**: Factory pattern with graceful fallback if engines not installed

### Usage

**GUI**: Select engine from dropdown, adjust sliders, generate audio

**CLI**:
```bash
# Coqui (default)
python vcloner.py -i voice.wav -t "Hello" -o output.wav

# Chatterbox Turbo with paralinguistic tag
python vcloner.py -i voice.wav -t "That's funny [laugh]!" -o output.wav \
    --engine chatterbox-turbo --cfg-weight 0.3 --exaggeration 0.7
```

**Python API**:
```python
from voice_cloner import VoiceCloner

cloner = VoiceCloner.from_chatterbox("voice.wav", variant="turbo")
cloner.say("Hello!", cfg_weight=0.3, exaggeration=0.7)
```

## Test plan

- [x] Tested Chatterbox Turbo with voice sample (geralt_original.mp3)
- [x] Tested paralinguistic tags (`[sigh]`) 
- [x] Verified backward compatibility with Coqui TTS
- [ ] Test GUI model switching
- [ ] Test on GPU (CUDA/MPS)