### PR TITLE
fix(ci): make CI fail on unit-test failures (#7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests/ -v --tb=short || echo "Tests skipped - ML models not available in CI"
+          pytest tests/ -v --tb=short
 
   pre-commit:
     name: Pre-commit Hooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
           pip install pytest pytest-cov
           # Install core dependencies (skip heavy ML packages for CI)
           pip install sounddevice soundfile rich numpy
+          # Install the project package (no deps — core ones are above)
+          pip install -e . --no-deps
 
       - name: Run tests
         run: |

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -91,6 +91,6 @@ def test_no_old_references_in_key_files():
             for context in contexts:
                 if context in line:
                     # These lines should not contain 'voice-cloner'
-                    assert "voice-cloner" not in line.lower(), (
-                        f"Found 'voice-cloner' in {filename}:{i + 1}: {line.strip()}"
-                    )
+                    assert (
+                        "voice-cloner" not in line.lower()
+                    ), f"Found 'voice-cloner' in {filename}:{i + 1}: {line.strip()}"

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -91,6 +91,6 @@ def test_no_old_references_in_key_files():
             for context in contexts:
                 if context in line:
                     # These lines should not contain 'voice-cloner'
-                    assert (
-                        "voice-cloner" not in line.lower()
-                    ), f"Found 'voice-cloner' in {filename}:{i + 1}: {line.strip()}"
+                    assert "voice-cloner" not in line.lower(), (
+                        f"Found 'voice-cloner' in {filename}:{i + 1}: {line.strip()}"
+                    )


### PR DESCRIPTION
## Summary

Remove `|| echo "Tests skipped..."` from the CI pytest command so that non-zero exit codes from pytest propagate and cause the CI run to fail when required unit tests fail.

## Approach

- Removed the `|| echo "Tests skipped - ML models not available in CI"` fallback from the `Run tests` step in `.github/workflows/ci.yml`
- Tests that depend on optional ML libraries (`test_voice_cloner.py`) already use `pytest.importorskip`, which gracefully skips them when dependencies are unavailable — no additional separation mechanism is needed
- Pure unit tests (`test_rename.py`, `test_model_management.py`) always run and their failures now correctly block CI

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Remove `|| echo` fallback from pytest command |

## Test Results

```
28 passed, 1 skipped in 0.04s
```

The 1 skipped test is from `test_voice_cloner.py` (missing ML dependencies in local env — expected).

## Acceptance Criteria Verification

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Unit-test failures cause the CI run to fail | ✅ pytest exit code now propagates |
| 2 | Optional/environment-dependent tests are clearly separated | ✅ `pytest.importorskip` handles this at module level |
| 3 | CI result accurately communicates required test pass/fail | ✅ exit code 0 = all required tests pass, non-zero = failure |

Closes #7