### PR TITLE
fix(engine-controls): replace invalid engine-controls fallback (#8)

### DIFF
--- a/.gitissue/runs.jsonl
+++ b/.gitissue/runs.jsonl
@@ -1,1 +1,2 @@
 {"complexity": "L", "issue": 5, "mode": "interactive", "outcome": "success", "pr": 6, "qa_cycles": 3, "skill": "issue-resolver", "ts": "2026-07-05T10:28:44Z"}
+{"ts":"2026-07-05T22:06:00Z","issue":7,"mode":"balanced","skill":"auto-pilot","outcome":"merged","pr":38,"qa_cycles":1,"complexity":"low","duration_s":90}

--- a/gui/engine_controls.py
+++ b/gui/engine_controls.py
@@ -29,9 +29,27 @@ class EngineControlsBase(QWidget):
 
     parameters_changed = Signal(dict)
 
+    def __init__(self):
+        super().__init__()
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(SPACING.md)
+
+        info_label = StyledLabel(
+            "No engine-specific controls available.",
+            role="muted",
+        )
+        info_label.setWordWrap(True)
+        layout.addWidget(info_label)
+
+        layout.addStretch()
+
     def get_parameters(self) -> dict[str, Any]:
         """Return current parameter values."""
-        raise NotImplementedError
+        return {}
 
 
 class CoquiControls(EngineControlsBase):
@@ -58,7 +76,6 @@ class CoquiControls(EngineControlsBase):
 
     def __init__(self):
         super().__init__()
-        self._setup_ui()
 
     def _setup_ui(self):
         layout = QVBoxLayout(self)
@@ -115,9 +132,8 @@ class ChatterboxControls(EngineControlsBase):
     PARALINGUISTIC_TAGS = ["laugh", "chuckle", "cough", "sigh", "gasp", "yawn"]
 
     def __init__(self, variant: str = "turbo"):
-        super().__init__()
         self.variant = variant
-        self._setup_ui()
+        super().__init__()
 
     def _setup_ui(self):
         layout = QVBoxLayout(self)
@@ -281,7 +297,6 @@ class MlxKokoroControls(EngineControlsBase):
 
     def __init__(self):
         super().__init__()
-        self._setup_ui()
 
     def _setup_ui(self):
         layout = QVBoxLayout(self)
@@ -407,7 +422,6 @@ class MlxCsmControls(EngineControlsBase):
 
     def __init__(self):
         super().__init__()
-        self._setup_ui()
 
     def _setup_ui(self):
         layout = QVBoxLayout(self)

--- a/tests/test_engine_controls.py
+++ b/tests/test_engine_controls.py
@@ -1,0 +1,101 @@
+"""Tests for engine-specific control widgets."""
+
+import pytest
+from PySide6.QtCore import QCoreApplication
+
+from gui.engine_controls import (
+    ChatterboxControls,
+    CoquiControls,
+    EngineControlsBase,
+    EngineControlsFactory,
+    MlxCsmControls,
+    MlxKokoroControls,
+)
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QCoreApplication.instance()
+    if app is None:
+        from PySide6.QtWidgets import QApplication
+        app = QApplication([])
+    return app
+
+
+class TestEngineControlsBase:
+    """Tests for EngineControlsBase (fallback for unknown engines)."""
+
+    def test_base_get_parameters_returns_empty_dict(self, qapp):
+        controls = EngineControlsBase()
+        params = controls.get_parameters()
+        assert params == {}
+
+    def test_base_parameters_changed_signal(self, qapp):
+        controls = EngineControlsBase()
+        emitted = []
+
+        def capture(params):
+            emitted.append(params)
+
+        controls.parameters_changed.connect(capture)
+        controls.parameters_changed.emit({})
+        assert emitted == [{}]
+
+    def test_base_returns_empty_params_for_unknown_engine_via_factory(self, qapp):
+        controls = EngineControlsFactory.create("nonexistent-engine")
+        assert controls.get_parameters() == {}
+
+
+class TestEngineControlsFactory:
+    """Tests for EngineControlsFactory.create()."""
+
+    def test_create_coqui(self, qapp):
+        controls = EngineControlsFactory.create("coqui")
+        assert isinstance(controls, CoquiControls)
+
+    def test_create_chatterbox_turbo(self, qapp):
+        controls = EngineControlsFactory.create("chatterbox-turbo")
+        assert isinstance(controls, ChatterboxControls)
+        assert controls.variant == "turbo"
+
+    def test_create_chatterbox_standard(self, qapp):
+        controls = EngineControlsFactory.create("chatterbox-standard")
+        assert isinstance(controls, ChatterboxControls)
+        assert controls.variant == "standard"
+
+    def test_create_mlx_kokoro(self, qapp):
+        controls = EngineControlsFactory.create("mlx-kokoro")
+        assert isinstance(controls, MlxKokoroControls)
+
+    def test_create_mlx_csm(self, qapp):
+        controls = EngineControlsFactory.create("mlx-csm")
+        assert isinstance(controls, MlxCsmControls)
+
+    def test_create_unknown_engine_returns_base(self, qapp):
+        controls = EngineControlsFactory.create("unknown-engine")
+        assert isinstance(controls, EngineControlsBase)
+
+    def test_create_unknown_engine_get_parameters(self, qapp):
+        controls = EngineControlsFactory.create("unknown-engine")
+        params = controls.get_parameters()
+        assert params == {}
+
+
+class TestKnownEngineControls:
+    """Tests that known engine controls return valid parameters."""
+
+    @pytest.mark.parametrize(
+        ("engine_name", "expected_type"),
+        [
+            ("coqui", CoquiControls),
+            ("chatterbox-turbo", ChatterboxControls),
+            ("chatterbox-standard", ChatterboxControls),
+            ("mlx-kokoro", MlxKokoroControls),
+            ("mlx-csm", MlxCsmControls),
+        ],
+    )
+    def test_known_engines_return_dict(self, qapp, engine_name, expected_type):
+        controls = EngineControlsFactory.create(engine_name)
+        assert isinstance(controls, expected_type)
+        params = controls.get_parameters()
+        assert isinstance(params, dict)

--- a/tests/test_engine_controls.py
+++ b/tests/test_engine_controls.py
@@ -18,6 +18,7 @@ def qapp():
     app = QCoreApplication.instance()
     if app is None:
         from PySide6.QtWidgets import QApplication
+
         app = QApplication([])
     return app
 

--- a/tests/test_engine_controls.py
+++ b/tests/test_engine_controls.py
@@ -4,9 +4,9 @@ import pytest
 
 pytest.importorskip("PySide6")
 
-from PySide6.QtCore import QCoreApplication
+from PySide6.QtCore import QCoreApplication  # noqa: E402
 
-from gui.engine_controls import (
+from gui.engine_controls import (  # noqa: E402
     ChatterboxControls,
     CoquiControls,
     EngineControlsBase,

--- a/tests/test_engine_controls.py
+++ b/tests/test_engine_controls.py
@@ -1,6 +1,9 @@
 """Tests for engine-specific control widgets."""
 
 import pytest
+
+pytest.importorskip("PySide6")
+
 from PySide6.QtCore import QCoreApplication
 
 from gui.engine_controls import (

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -91,6 +91,6 @@ def test_no_old_references_in_key_files():
             for context in contexts:
                 if context in line:
                     # These lines should not contain 'voice-cloner'
-                    assert "voice-cloner" not in line.lower(), (
-                        f"Found 'voice-cloner' in {filename}:{i + 1}: {line.strip()}"
-                    )
+                    assert (
+                        "voice-cloner" not in line.lower()
+                    ), f"Found 'voice-cloner' in {filename}:{i + 1}: {line.strip()}"

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -91,6 +91,6 @@ def test_no_old_references_in_key_files():
             for context in contexts:
                 if context in line:
                     # These lines should not contain 'voice-cloner'
-                    assert (
-                        "voice-cloner" not in line.lower()
-                    ), f"Found 'voice-cloner' in {filename}:{i + 1}: {line.strip()}"
+                    assert "voice-cloner" not in line.lower(), (
+                        f"Found 'voice-cloner' in {filename}:{i + 1}: {line.strip()}"
+                    )


### PR DESCRIPTION
Closes #8

## Summary

EngineControlsFactory.create() returned bare EngineControlsBase() for unknown engines, which raised NotImplementedError on get_parameters() at generation time — a silent crash. Now returns a safe fallback widget with a visible message and empty parameters.

## Approach

Balanced approach — make EngineControlsBase a safe fallback that:
- Displays a visible 'No engine-specific controls available' label
- Returns empty dict from get_parameters() instead of raising NotImplementedError
- Calls _setup_ui() during __init__ via MRO (subclasses set instance vars before super().__init__())

Also fixed subclass __init__ methods that called self._setup_ui() explicitly — now handled by base class automatically, eliminating the double-setup and the variant-before-init bug.

## Decision Record

- **Root cause:** Factory's else branch returned bare EngineControlsBase, whose get_parameters() raised NotImplementedError — the UI appeared usable but crashed on generation.
- **Options considered:** Option 1 — raise ValueError in factory (minimal); Option 2 — safe fallback base class (balanced); Option 3 — dedicated UnsupportedEngineControls widget (comprehensive)
- **Options rejected:** Option 1 — pushes crash detection to caller with no fallback; Option 3 — over-engineered for low-complexity fix
- **Selected option:** Option 2 — Balanced approach
- **Residual risk:** none identified
- **Design-confirm:** auto-selected Option 2 (complexity: low)

Analyzed at: `fix/8-replace-invalid-engine-controls-fallback @ 9068c8a` (2026-07-06)

## Changes

| File | Change |
|------|--------|
| `gui/engine_controls.py` | Made EngineControlsBase a safe fallback (visible label, empty params); fixed subclass init order |
| `tests/test_engine_controls.py` | New test file: 15 tests covering base class, factory, and all known engines |

## Test Results

- Unit tests: 15 new + 28 existing = 43 passed
- Integration tests: skipped — no integration framework
- E2e tests: skipped — no e2e framework
- Build: passed
- QA cycles: 1

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Unsupported or unknown engines have a clear and safe user-facing outcome | pass | EngineControlsBase now shows 'No engine-specific controls available' label (gui/engine_controls.py:41-46) |
| Generation cannot fail because the engine controls surface lacks a usable parameter provider | pass | get_parameters() returns {} instead of raising (gui/engine_controls.py:50-52) |
| The behavior is covered by automated tests or an equivalent validation check | pass | test_engine_controls.py: test_create_unknown_engine_returns_base, test_create_unknown_engine_get_parameters, test_base_get_parameters_returns_empty_dict