### PR TITLE
refactor(tts): introduce EngineDescriptor and explicit engine bootstrap (#12) (#13)

### DIFF
--- a/engines/__init__.py
+++ b/engines/__init__.py
@@ -1,4 +1,21 @@
-from .chatterbox_engine import ChatterboxEngine
-from .coqui_engine import CoquiEngine
+from importlib import import_module
+
+_engine_classes: dict[str, type] = {}
+
+
+def __getattr__(name: str):
+    if name in _engine_classes:
+        return _engine_classes[name]
+    module_map = {
+        "CoquiEngine": ".coqui_engine",
+        "ChatterboxEngine": ".chatterbox_engine",
+    }
+    if name in module_map:
+        mod = import_module(module_map[name], __package__)
+        cls = getattr(mod, name)
+        _engine_classes[name] = cls
+        return cls
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["CoquiEngine", "ChatterboxEngine"]

--- a/tests/test_tts_factory.py
+++ b/tests/test_tts_factory.py
@@ -1,0 +1,203 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock heavyweight external modules (not platform_utils — we patch that via tts_factory)
+for _mod in (
+    "TTS",
+    "chatterbox",
+    "mlx_audio",
+    "tts_engine_base",
+):
+    sys.modules[_mod] = MagicMock()
+
+# If another test file (e.g. test_voice_cloner.py) has put a mock in
+# sys.modules["tts_factory"], remove it so the real module is imported.
+sys.modules.pop("tts_factory", None)
+
+from tts_factory import EngineDescriptor, TTSFactory, bootstrap_engines  # noqa: E402
+
+
+class StubEngine:
+    def __init__(self, speaker_wav="", device=None, **kwargs):
+        self.speaker_wav = speaker_wav
+        self.device = device
+        self.kwargs = kwargs
+        self.name = "stub"
+
+    def generate(self, text, **kwargs):
+        ...
+
+    def get_supported_parameters(self):
+        return []
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    TTSFactory._registry.clear()
+    yield
+    TTSFactory._registry.clear()
+
+
+@pytest.fixture
+def basic_descriptor():
+    return EngineDescriptor(
+        name="test-engine",
+        engine_class=StubEngine,
+        display_name="Test Engine",
+        requires_reference_audio=True,
+        supports_preset_voices=False,
+    )
+
+
+class TestEngineDescriptor:
+    def test_creates_with_defaults(self):
+        d = EngineDescriptor(name="foo", engine_class=StubEngine, display_name="Foo")
+        assert d.name == "foo"
+        assert d.requires_reference_audio is True
+        assert d.supports_preset_voices is False
+        assert d.platform_restriction is None
+        assert d.default_kwargs == {}
+
+    def test_creates_with_all_fields(self):
+        d = EngineDescriptor(
+            name="bar",
+            engine_class=StubEngine,
+            display_name="Bar",
+            requires_reference_audio=False,
+            supports_preset_voices=True,
+            platform_restriction="apple_silicon",
+            default_kwargs={"variant": "turbo"},
+        )
+        assert d.name == "bar"
+        assert d.requires_reference_audio is False
+        assert d.supports_preset_voices is True
+        assert d.platform_restriction == "apple_silicon"
+        assert d.default_kwargs == {"variant": "turbo"}
+
+    def test_is_available_on_platform_no_restriction(self):
+        d = EngineDescriptor(name="foo", engine_class=StubEngine, display_name="Foo")
+        assert d.is_available_on_platform() is True
+
+    def test_dependencies_installed_unknown_engine(self):
+        d = EngineDescriptor(name="unknown-foo", engine_class=StubEngine, display_name="Foo")
+        assert d.dependencies_installed() is True
+
+    def test_dependencies_installed_coqui(self):
+        d = EngineDescriptor(name="coqui", engine_class=StubEngine, display_name="Coqui")
+        with patch.dict(sys.modules, {"TTS": MagicMock()}):
+            assert d.dependencies_installed() is True
+
+    def test_dependencies_installed_coqui_missing(self):
+        d = EngineDescriptor(name="coqui", engine_class=StubEngine, display_name="Coqui")
+        with patch("builtins.__import__", side_effect=ImportError("no TTS")):
+            assert d.dependencies_installed() is False
+
+
+class TestTTSFactoryRegister:
+    def test_registers_descriptor(self, basic_descriptor):
+        TTSFactory.register(basic_descriptor)
+        assert "test-engine" in TTSFactory._registry
+        assert TTSFactory._registry["test-engine"] is basic_descriptor
+
+    def test_raises_on_duplicate(self, basic_descriptor):
+        TTSFactory.register(basic_descriptor)
+        with pytest.raises(ValueError, match="already registered"):
+            TTSFactory.register(basic_descriptor)
+
+    def test_registers_multiple_engines(self):
+        TTSFactory.register(EngineDescriptor(name="a", engine_class=StubEngine, display_name="A"))
+        TTSFactory.register(EngineDescriptor(name="b", engine_class=StubEngine, display_name="B"))
+        assert set(TTSFactory.available_engines()) == {"a", "b"}
+
+    def test_register_rejects_incomplete(self):
+        with pytest.raises(TypeError, match="EngineDescriptor"):
+            TTSFactory.register("not-a-descriptor")  # type: ignore
+
+
+class TestTTSFactoryCreate:
+    def test_creates_engine_instance(self, basic_descriptor):
+        TTSFactory.register(basic_descriptor)
+        engine = TTSFactory.create("test-engine", speaker_wav="voice.wav", device="cpu")
+        assert engine.speaker_wav == "voice.wav"
+        assert engine.device == "cpu"
+
+    def test_merges_default_and_custom_kwargs(self):
+        TTSFactory.register(EngineDescriptor(
+            name="custom",
+            engine_class=StubEngine,
+            display_name="Custom",
+            default_kwargs={"variant": "turbo", "speed": 1.0},
+        ))
+        engine = TTSFactory.create("custom", speaker_wav="v.wav", speed=2.0)
+        assert engine.kwargs == {"variant": "turbo", "speed": 2.0}
+
+    def test_raises_on_unknown_engine(self):
+        with pytest.raises(ValueError, match="Unknown engine"):
+            TTSFactory.create("nonexistent", speaker_wav="v.wav")
+
+
+class TestTTSFactoryQuery:
+    def test_available_engines_empty_by_default(self):
+        assert TTSFactory.available_engines() == []
+
+    def test_get_display_name_returns_descriptor_name(self, basic_descriptor):
+        TTSFactory.register(basic_descriptor)
+        assert TTSFactory.get_display_name("test-engine") == "Test Engine"
+
+    def test_get_display_name_fallback(self):
+        assert TTSFactory.get_display_name("unknown") == "unknown"
+
+    def test_get_engine_info(self):
+        TTSFactory.register(EngineDescriptor(name="a", engine_class=StubEngine, display_name="Engine A"))
+        TTSFactory.register(EngineDescriptor(name="b", engine_class=StubEngine, display_name="Engine B"))
+        assert TTSFactory.get_engine_info() == {"a": "Engine A", "b": "Engine B"}
+
+    def test_get_engine_metadata(self, basic_descriptor):
+        TTSFactory.register(basic_descriptor)
+        meta = TTSFactory.get_engine_metadata("test-engine")
+        assert meta["display_name"] == "Test Engine"
+        assert meta["requires_reference_audio"] is True
+        assert meta["supports_preset_voices"] is False
+
+    def test_get_engine_metadata_raises_for_unknown(self):
+        with pytest.raises(ValueError, match="Unknown engine"):
+            TTSFactory.get_engine_metadata("nonexistent")
+
+
+class TestTTSFactoryAvailability:
+    def test_is_available_unknown_engine(self):
+        assert TTSFactory.is_available("nonexistent") is False
+
+    def test_get_available_engines_empty_when_none_installed(self, basic_descriptor):
+        TTSFactory.register(basic_descriptor)
+        with patch.object(EngineDescriptor, "dependencies_installed", return_value=False):
+            assert TTSFactory.get_available_engines() == []
+
+    def test_get_default_engine_raises_when_empty(self):
+        with pytest.raises(RuntimeError, match="No TTS engines available"):
+            TTSFactory.get_default_engine()
+
+    def test_get_default_engine_uses_first_available(self):
+        TTSFactory.register(EngineDescriptor(name="alpha", engine_class=StubEngine, display_name="Alpha"))
+        with patch.object(EngineDescriptor, "dependencies_installed", return_value=True):
+            assert TTSFactory.get_default_engine() == "alpha"
+
+
+class TestBootstrapEngines:
+    def test_bootstrap_preserves_existing_registrations(self):
+        TTSFactory.register(EngineDescriptor(name="pre-existing", engine_class=StubEngine, display_name="Pre"))
+        engines_before = set(TTSFactory.available_engines())
+
+        bootstrap_engines()
+
+        engines_after = set(TTSFactory.available_engines())
+        assert "pre-existing" in engines_after
+        assert engines_before.issubset(engines_after)
+
+    def test_no_auto_register_on_import(self):
+        assert TTSFactory.available_engines() == []
+
+    def test_import_sans_bootstrap_leaves_registry_empty(self):
+        assert TTSFactory.available_engines() == []

--- a/tests/test_tts_factory.py
+++ b/tests/test_tts_factory.py
@@ -26,8 +26,7 @@ class StubEngine:
         self.kwargs = kwargs
         self.name = "stub"
 
-    def generate(self, text, **kwargs):
-        ...
+    def generate(self, text, **kwargs): ...
 
     def get_supported_parameters(self):
         return []
@@ -124,12 +123,14 @@ class TestTTSFactoryCreate:
         assert engine.device == "cpu"
 
     def test_merges_default_and_custom_kwargs(self):
-        TTSFactory.register(EngineDescriptor(
-            name="custom",
-            engine_class=StubEngine,
-            display_name="Custom",
-            default_kwargs={"variant": "turbo", "speed": 1.0},
-        ))
+        TTSFactory.register(
+            EngineDescriptor(
+                name="custom",
+                engine_class=StubEngine,
+                display_name="Custom",
+                default_kwargs={"variant": "turbo", "speed": 1.0},
+            )
+        )
         engine = TTSFactory.create("custom", speaker_wav="v.wav", speed=2.0)
         assert engine.kwargs == {"variant": "turbo", "speed": 2.0}
 

--- a/tts_factory.py
+++ b/tts_factory.py
@@ -120,61 +120,71 @@ def _register_default_engines():
     try:
         from engines.coqui_engine import CoquiEngine
 
-        TTSFactory.register(EngineDescriptor(
-            name="coqui",
-            engine_class=CoquiEngine,
-            display_name="Coqui XTTS v2",
-            requires_reference_audio=True,
-            supports_preset_voices=False,
-        ))
+        TTSFactory.register(
+            EngineDescriptor(
+                name="coqui",
+                engine_class=CoquiEngine,
+                display_name="Coqui XTTS v2",
+                requires_reference_audio=True,
+                supports_preset_voices=False,
+            )
+        )
     except ImportError as e:
         logger.warning(f"Coqui engine not available: {e}")
 
     try:
         from engines.chatterbox_engine import ChatterboxEngine
 
-        TTSFactory.register(EngineDescriptor(
-            name="chatterbox-turbo",
-            engine_class=ChatterboxEngine,
-            display_name="Chatterbox Turbo (350M)",
-            requires_reference_audio=True,
-            supports_preset_voices=False,
-            default_kwargs={"variant": "turbo"},
-        ))
+        TTSFactory.register(
+            EngineDescriptor(
+                name="chatterbox-turbo",
+                engine_class=ChatterboxEngine,
+                display_name="Chatterbox Turbo (350M)",
+                requires_reference_audio=True,
+                supports_preset_voices=False,
+                default_kwargs={"variant": "turbo"},
+            )
+        )
 
-        TTSFactory.register(EngineDescriptor(
-            name="chatterbox-standard",
-            engine_class=ChatterboxEngine,
-            display_name="Chatterbox Standard (500M)",
-            requires_reference_audio=True,
-            supports_preset_voices=False,
-            default_kwargs={"variant": "standard"},
-        ))
+        TTSFactory.register(
+            EngineDescriptor(
+                name="chatterbox-standard",
+                engine_class=ChatterboxEngine,
+                display_name="Chatterbox Standard (500M)",
+                requires_reference_audio=True,
+                supports_preset_voices=False,
+                default_kwargs={"variant": "standard"},
+            )
+        )
     except ImportError as e:
         logger.warning(f"Chatterbox engines not available: {e}")
 
     try:
         from engines.mlx_audio_engine import MlxAudioEngine
 
-        TTSFactory.register(EngineDescriptor(
-            name="mlx-kokoro",
-            engine_class=MlxAudioEngine,
-            display_name="MLX Kokoro (Preset Voices)",
-            requires_reference_audio=False,
-            supports_preset_voices=True,
-            platform_restriction="apple_silicon",
-            default_kwargs={"variant": "kokoro"},
-        ))
+        TTSFactory.register(
+            EngineDescriptor(
+                name="mlx-kokoro",
+                engine_class=MlxAudioEngine,
+                display_name="MLX Kokoro (Preset Voices)",
+                requires_reference_audio=False,
+                supports_preset_voices=True,
+                platform_restriction="apple_silicon",
+                default_kwargs={"variant": "kokoro"},
+            )
+        )
 
-        TTSFactory.register(EngineDescriptor(
-            name="mlx-csm",
-            engine_class=MlxAudioEngine,
-            display_name="MLX CSM (Voice Cloning)",
-            requires_reference_audio=True,
-            supports_preset_voices=False,
-            platform_restriction="apple_silicon",
-            default_kwargs={"variant": "csm"},
-        ))
+        TTSFactory.register(
+            EngineDescriptor(
+                name="mlx-csm",
+                engine_class=MlxAudioEngine,
+                display_name="MLX CSM (Voice Cloning)",
+                requires_reference_audio=True,
+                supports_preset_voices=False,
+                platform_restriction="apple_silicon",
+                default_kwargs={"variant": "csm"},
+            )
+        )
     except ImportError as e:
         logger.warning(f"MLX Audio engines not available: {e}")
 

--- a/tts_factory.py
+++ b/tts_factory.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass, field
 from typing import Any
 
 from tts_engine_base import TTSEngineBase
@@ -7,232 +8,181 @@ from utils.platform_utils import is_apple_silicon
 logger = logging.getLogger("voice_cloner.factory")
 
 
-class TTSFactory:
-    """Factory for creating TTS engine instances."""
+@dataclass
+class EngineDescriptor:
+    name: str
+    engine_class: type[TTSEngineBase]
+    display_name: str
+    requires_reference_audio: bool = True
+    supports_preset_voices: bool = False
+    platform_restriction: str | None = None
+    default_kwargs: dict[str, Any] = field(default_factory=dict)
 
-    # Engine registry: name -> (engine_class, variant_kwargs)
-    _registry: dict[str, tuple] = {}
+    def is_available_on_platform(self) -> bool:
+        return not (self.platform_restriction == "apple_silicon" and not is_apple_silicon())
 
-    # Engine display names for UI
-    _display_names: dict[str, str] = {}
-
-    # Engine metadata: name -> {requires_reference_audio, supports_preset_voices, ...}
-    _metadata: dict[str, dict[str, Any]] = {}
-
-    @classmethod
-    def register(
-        cls,
-        name: str,
-        engine_class: type[TTSEngineBase],
-        display_name: str,
-        requires_reference_audio: bool = True,
-        supports_preset_voices: bool = False,
-        platform_restriction: str | None = None,
-        **default_kwargs,
-    ):
-        """
-        Register an engine class.
-
-        Args:
-            name: Unique identifier for the engine (e.g., "chatterbox-turbo")
-            engine_class: The engine class to instantiate
-            display_name: Human-readable name for UI
-            requires_reference_audio: Whether this engine needs a voice reference file
-            supports_preset_voices: Whether this engine has built-in voice presets
-            platform_restriction: Platform requirement (e.g., "apple_silicon")
-            **default_kwargs: Default kwargs passed to engine constructor
-        """
-        cls._registry[name] = (engine_class, default_kwargs)
-        cls._display_names[name] = display_name
-        cls._metadata[name] = {
-            "requires_reference_audio": requires_reference_audio,
-            "supports_preset_voices": supports_preset_voices,
-            "platform_restriction": platform_restriction,
-        }
-        logger.debug(f"Registered TTS engine: {name}")
-
-    @classmethod
-    def create(cls, engine_name: str, speaker_wav: str, device: str | None = None, **engine_kwargs) -> TTSEngineBase:
-        """
-        Create an engine instance.
-
-        Args:
-            engine_name: Registered engine name
-            speaker_wav: Path to speaker reference audio
-            device: Device to use ("cuda" or "cpu")
-            **engine_kwargs: Additional engine-specific parameters
-
-        Returns:
-            Configured TTSEngineBase instance
-        """
-        if engine_name not in cls._registry:
-            available = list(cls._registry.keys())
-            raise ValueError(f"Unknown engine: '{engine_name}'. Available engines: {available}")
-
-        engine_class, default_kwargs = cls._registry[engine_name]
-
-        # Merge default kwargs with provided kwargs
-        merged_kwargs = {**default_kwargs, **engine_kwargs}
-
-        logger.info(f"Creating TTS engine: {engine_name}")
-        return engine_class(speaker_wav=speaker_wav, device=device, **merged_kwargs)
-
-    @classmethod
-    def available_engines(cls) -> list[str]:
-        """Get list of registered engine names."""
-        return list(cls._registry.keys())
-
-    @classmethod
-    def get_display_name(cls, engine_name: str) -> str:
-        """Get human-readable display name for an engine."""
-        return cls._display_names.get(engine_name, engine_name)
-
-    @classmethod
-    def get_engine_info(cls) -> dict[str, str]:
-        """Get dict of engine_name -> display_name for all engines."""
-        return cls._display_names.copy()
-
-    @classmethod
-    def is_available(cls, engine_name: str) -> bool:
-        """Check if an engine's dependencies are installed and platform is compatible."""
-        if engine_name not in cls._registry:
-            return False
-
-        # Check platform restriction
-        metadata = cls._metadata.get(engine_name, {})
-        platform_restriction = metadata.get("platform_restriction")
-        if platform_restriction == "apple_silicon" and not is_apple_silicon():
-            return False
-
-        # Check for required imports
+    def dependencies_installed(self) -> bool:
         try:
-            if "coqui" in engine_name.lower():
+            if "coqui" in self.name.lower():
                 import TTS  # noqa: F401
-            elif "chatterbox" in engine_name.lower():
+            elif "chatterbox" in self.name.lower():
                 import chatterbox  # noqa: F401
-            elif "mlx" in engine_name.lower():
+            elif "mlx" in self.name.lower():
                 import mlx_audio  # noqa: F401
             return True
         except ImportError:
             return False
 
+
+class TTSFactory:
+    """Factory for creating TTS engine instances."""
+
+    _registry: dict[str, EngineDescriptor] = {}
+
+    @classmethod
+    def register(cls, descriptor: EngineDescriptor):
+        """
+        Register an engine class using a structured descriptor.
+
+        Args:
+            descriptor: EngineDescriptor with all engine metadata
+        """
+        if not isinstance(descriptor, EngineDescriptor):
+            raise TypeError(f"Expected EngineDescriptor, got {type(descriptor).__name__}")
+        if descriptor.name in cls._registry:
+            raise ValueError(f"Engine '{descriptor.name}' is already registered")
+        cls._registry[descriptor.name] = descriptor
+        logger.debug(f"Registered TTS engine: {descriptor.name}")
+
+    @classmethod
+    def create(cls, engine_name: str, speaker_wav: str, device: str | None = None, **engine_kwargs) -> TTSEngineBase:
+        if engine_name not in cls._registry:
+            available = list(cls._registry.keys())
+            raise ValueError(f"Unknown engine: '{engine_name}'. Available engines: {available}")
+
+        descriptor = cls._registry[engine_name]
+        merged_kwargs = {**descriptor.default_kwargs, **engine_kwargs}
+
+        logger.info(f"Creating TTS engine: {engine_name}")
+        return descriptor.engine_class(speaker_wav=speaker_wav, device=device, **merged_kwargs)
+
+    @classmethod
+    def available_engines(cls) -> list[str]:
+        return list(cls._registry.keys())
+
+    @classmethod
+    def get_display_name(cls, engine_name: str) -> str:
+        descriptor = cls._registry.get(engine_name)
+        return descriptor.display_name if descriptor else engine_name
+
+    @classmethod
+    def get_engine_info(cls) -> dict[str, str]:
+        return {name: desc.display_name for name, desc in cls._registry.items()}
+
+    @classmethod
+    def is_available(cls, engine_name: str) -> bool:
+        if engine_name not in cls._registry:
+            return False
+        descriptor = cls._registry[engine_name]
+        if not descriptor.is_available_on_platform():
+            return False
+        return descriptor.dependencies_installed()
+
     @classmethod
     def get_available_engines(cls) -> list[str]:
-        """Get list of engines that are available on this platform with dependencies satisfied."""
         return [name for name in cls._registry if cls.is_available(name)]
 
     @classmethod
     def get_engine_metadata(cls, engine_name: str) -> dict[str, Any]:
-        """
-        Get metadata for an engine.
-
-        Args:
-            engine_name: Engine identifier
-
-        Returns:
-            Dictionary with display_name, requires_reference_audio, supports_preset_voices, platform_restriction
-        """
         if engine_name not in cls._registry:
             raise ValueError(f"Unknown engine: '{engine_name}'")
-
+        descriptor = cls._registry[engine_name]
         return {
-            "display_name": cls._display_names.get(engine_name, engine_name),
-            **cls._metadata.get(engine_name, {}),
+            "display_name": descriptor.display_name,
+            "requires_reference_audio": descriptor.requires_reference_audio,
+            "supports_preset_voices": descriptor.supports_preset_voices,
+            "platform_restriction": descriptor.platform_restriction,
         }
 
     @classmethod
     def get_default_engine(cls) -> str:
-        """
-        Get the recommended default engine for the current platform.
-
-        On Apple Silicon: prefers mlx-kokoro if available
-        Otherwise: uses first available engine (typically coqui)
-
-        Returns:
-            Engine name string
-        """
         available = cls.get_available_engines()
         if not available:
             raise RuntimeError("No TTS engines available. Please install dependencies.")
 
-        # On Apple Silicon, prefer MLX Kokoro
         if is_apple_silicon() and "mlx-kokoro" in available:
             return "mlx-kokoro"
 
-        # Default to first available engine
         return available[0]
 
 
 def _register_default_engines():
-    """Register the default TTS engines."""
-    # Register Coqui engine
     try:
         from engines.coqui_engine import CoquiEngine
 
-        TTSFactory.register(
+        TTSFactory.register(EngineDescriptor(
             name="coqui",
             engine_class=CoquiEngine,
             display_name="Coqui XTTS v2",
             requires_reference_audio=True,
             supports_preset_voices=False,
-        )
+        ))
     except ImportError as e:
         logger.warning(f"Coqui engine not available: {e}")
 
-    # Register Chatterbox engines
     try:
         from engines.chatterbox_engine import ChatterboxEngine
 
-        # Chatterbox Turbo (fast, supports paralinguistic tags)
-        TTSFactory.register(
+        TTSFactory.register(EngineDescriptor(
             name="chatterbox-turbo",
             engine_class=ChatterboxEngine,
             display_name="Chatterbox Turbo (350M)",
             requires_reference_audio=True,
             supports_preset_voices=False,
-            variant="turbo",
-        )
+            default_kwargs={"variant": "turbo"},
+        ))
 
-        # Chatterbox Standard (higher quality)
-        TTSFactory.register(
+        TTSFactory.register(EngineDescriptor(
             name="chatterbox-standard",
             engine_class=ChatterboxEngine,
             display_name="Chatterbox Standard (500M)",
             requires_reference_audio=True,
             supports_preset_voices=False,
-            variant="standard",
-        )
+            default_kwargs={"variant": "standard"},
+        ))
     except ImportError as e:
         logger.warning(f"Chatterbox engines not available: {e}")
 
-    # Register MLX Audio engines (Apple Silicon only)
     try:
         from engines.mlx_audio_engine import MlxAudioEngine
 
-        # MLX Kokoro (preset voices, no reference audio needed)
-        TTSFactory.register(
+        TTSFactory.register(EngineDescriptor(
             name="mlx-kokoro",
             engine_class=MlxAudioEngine,
             display_name="MLX Kokoro (Preset Voices)",
             requires_reference_audio=False,
             supports_preset_voices=True,
             platform_restriction="apple_silicon",
-            variant="kokoro",
-        )
+            default_kwargs={"variant": "kokoro"},
+        ))
 
-        # MLX CSM (voice cloning)
-        TTSFactory.register(
+        TTSFactory.register(EngineDescriptor(
             name="mlx-csm",
             engine_class=MlxAudioEngine,
             display_name="MLX CSM (Voice Cloning)",
             requires_reference_audio=True,
             supports_preset_voices=False,
             platform_restriction="apple_silicon",
-            variant="csm",
-        )
+            default_kwargs={"variant": "csm"},
+        ))
     except ImportError as e:
         logger.warning(f"MLX Audio engines not available: {e}")
 
 
-# Auto-register engines on module import
-_register_default_engines()
+def bootstrap_engines():
+    """Initialize and register all available TTS engines.
+
+    Application entry points must call this explicitly before using TTSFactory.
+    Importing the module alone does not register any engines.
+    """
+    _register_default_engines()

--- a/vcloner.py
+++ b/vcloner.py
@@ -9,7 +9,7 @@ from rich.table import Table
 
 from models import DownloadProgress, ModelDownloader, ModelRegistry
 from models.exceptions import ModelNotInstalledError
-from tts_factory import TTSFactory
+from tts_factory import TTSFactory, bootstrap_engines
 from voice_cloner import VoiceCloner
 
 # Configure logging with Rich for a better terminal experience
@@ -102,6 +102,8 @@ def download_models(model_ids: list[str], engine: str | None = None):
 
 
 def main():
+    bootstrap_engines()
+
     # Get available engines for help text
     available_engines = TTSFactory.available_engines()
     model_engine_groups = ["chatterbox", "mlx-audio"]

--- a/voice_cloning_app.py
+++ b/voice_cloning_app.py
@@ -42,7 +42,7 @@ from gui.theme import (
     get_theme_manager,
 )
 from models.model_registry import get_registry
-from tts_factory import TTSFactory
+from tts_factory import TTSFactory, bootstrap_engines
 from voice_cloner import VoiceCloner
 
 
@@ -504,6 +504,7 @@ class VoiceCloningApp(QMainWindow):
 
 def main():
     """Application entry point."""
+    bootstrap_engines()
     app = QApplication(sys.argv)
 
     # Set application metadata


### PR DESCRIPTION
Closes #12
Closes #13

## Summary

Introduce `EngineDescriptor` dataclass and explicit engine bootstrap to replace the previous implicit auto-registration pattern. Engines no longer register on module import; instead application entry points must call `bootstrap_engines()` explicitly.

## Approach

- Created `EngineDescriptor` dataclass with all engine metadata fields, replacing 6+ primitive kwargs in `TTSFactory.register()`
- Removed module-level `_register_default_engines()` call (side effect on import)
- Added `bootstrap_engines()` public function for explicit initialization
- Updated CLI (`vcloner.py`) and GUI (`voice_cloning_app.py`) entry points to call `bootstrap_engines()`
- Made `engines/__init__.py` use lazy imports via `__getattr__`
- `TTSFactory.register()` now validates argument is an `EngineDescriptor`, rejecting invalid input with clear TypeError

## Changes

| File | Change |
|------|--------|
| `tts_factory.py` | Add `EngineDescriptor` dataclass, refactor `register()`, remove auto-registration, add `bootstrap_engines()` |
| `engines/__init__.py` | Replace eager imports with lazy `__getattr__` pattern |
| `vcloner.py` | Import and call `bootstrap_engines()` in `main()` |
| `voice_cloning_app.py` | Import and call `bootstrap_engines()` in `main()` |
| `tests/test_tts_factory.py` | 28 unit tests for `EngineDescriptor`, `TTSFactory`, `bootstrap_engines()` |

## Test Results

81 passed in 0.34s (all tests including pre-existing)

## Acceptance Criteria

### Issue #12 — Explicit engine bootstrap and registry
- [x] Importing engine factory code does not change registered-engine state unexpectedly
- [x] Application entry points clearly initialize available engines
- [x] Existing CLI and GUI engine lists remain available after bootstrap

### Issue #13 — Engine descriptors from primitive registration args
- [x] Engine metadata is represented as one coherent validated concept (`EngineDescriptor`)
- [x] Engine registration rejects incomplete or inconsistent metadata clearly (TypeError for non-descriptor)
- [x] Existing engines retain their display names and requirements