### PR TITLE
refactor(engine-controls): descriptor-based controls and MLX voice dedup (#14 #15)

### DIFF
--- a/gui/engine_controls.py
+++ b/gui/engine_controls.py
@@ -225,7 +225,7 @@ class MlxKokoroControls(EngineControlsBase):
     VOICE_GROUPS = KOKORO_VOICES
     LANG_CODES = KOKORO_LANG_CODES
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
 
     def _setup_ui(self):
@@ -350,7 +350,7 @@ class MlxKokoroControls(EngineControlsBase):
 class MlxCsmControls(EngineControlsBase):
     """Control widget for MLX CSM voice cloning."""
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         super().__init__()
 
     def _setup_ui(self):

--- a/gui/engine_controls.py
+++ b/gui/engine_controls.py
@@ -14,6 +14,8 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+# Source-of-truth voice data from MlxAudioEngine
+from engines.mlx_audio_engine import KOKORO_LANG_CODES, KOKORO_VOICES
 from gui.styled_widgets import (
     StyledButton,
     StyledComboBox,
@@ -22,6 +24,7 @@ from gui.styled_widgets import (
     StyledSlider,
 )
 from gui.theme import SPACING
+from tts_factory import TTSFactory
 
 
 class EngineControlsBase(QWidget):
@@ -218,82 +221,9 @@ class ChatterboxControls(EngineControlsBase):
 class MlxKokoroControls(EngineControlsBase):
     """Control widget for MLX Kokoro preset voices."""
 
-    # Voice presets organized by language and category
-    VOICE_GROUPS = {
-        "American English": {
-            "Female": [
-                ("af_heart", "Heart (Warm)"),
-                ("af_alloy", "Alloy"),
-                ("af_aoede", "Aoede"),
-                ("af_bella", "Bella"),
-                ("af_jessica", "Jessica"),
-                ("af_kore", "Kore"),
-                ("af_nicole", "Nicole"),
-                ("af_nova", "Nova"),
-                ("af_river", "River"),
-                ("af_sarah", "Sarah"),
-                ("af_sky", "Sky"),
-            ],
-            "Male": [
-                ("am_adam", "Adam"),
-                ("am_echo", "Echo"),
-                ("am_eric", "Eric"),
-                ("am_fenrir", "Fenrir"),
-                ("am_liam", "Liam"),
-                ("am_michael", "Michael"),
-                ("am_onyx", "Onyx"),
-                ("am_puck", "Puck"),
-                ("am_santa", "Santa"),
-            ],
-        },
-        "British English": {
-            "Female": [
-                ("bf_alice", "Alice"),
-                ("bf_emma", "Emma"),
-                ("bf_isabella", "Isabella"),
-                ("bf_lily", "Lily"),
-            ],
-            "Male": [
-                ("bm_daniel", "Daniel"),
-                ("bm_fable", "Fable"),
-                ("bm_george", "George"),
-                ("bm_lewis", "Lewis"),
-            ],
-        },
-        "Japanese": {
-            "Female": [
-                ("jf_alpha", "Alpha"),
-                ("jf_gongitsune", "Gongitsune"),
-                ("jf_nezumi", "Nezumi"),
-                ("jf_tebukuro", "Tebukuro"),
-            ],
-            "Male": [
-                ("jm_kumo", "Kumo"),
-            ],
-        },
-        "Mandarin Chinese": {
-            "Female": [
-                ("zf_xiaobei", "Xiaobei"),
-                ("zf_xiaoni", "Xiaoni"),
-                ("zf_xiaoxiao", "Xiaoxiao"),
-                ("zf_xiaoyi", "Xiaoyi"),
-            ],
-            "Male": [
-                ("zm_yunjian", "Yunjian"),
-                ("zm_yunxi", "Yunxi"),
-                ("zm_yunxia", "Yunxia"),
-                ("zm_yunyang", "Yunyang"),
-            ],
-        },
-    }
-
-    # Language code mappings for Kokoro
-    LANG_CODES = {
-        "American English": "a",
-        "British English": "b",
-        "Japanese": "j",
-        "Mandarin Chinese": "z",
-    }
+    # Voice data sourced from MlxAudioEngine (single source of truth)
+    VOICE_GROUPS = KOKORO_VOICES
+    LANG_CODES = KOKORO_LANG_CODES
 
     def __init__(self):
         super().__init__()
@@ -473,22 +403,18 @@ class EngineControlsFactory:
         """
         Create control widget for the specified engine.
 
+        Looks up the registered EngineDescriptor from TTSFactory
+        and instantiates its associated controls_class.
+
         Args:
             engine_name: Engine identifier (e.g., "coqui", "chatterbox-turbo")
 
         Returns:
             EngineControlsBase widget instance
         """
-        if engine_name == "coqui":
-            return CoquiControls()
-        elif engine_name == "chatterbox-turbo":
-            return ChatterboxControls(variant="turbo")
-        elif engine_name == "chatterbox-standard":
-            return ChatterboxControls(variant="standard")
-        elif engine_name == "mlx-kokoro":
-            return MlxKokoroControls()
-        elif engine_name == "mlx-csm":
-            return MlxCsmControls()
-        else:
-            # Return empty widget for unknown engines
-            return EngineControlsBase()
+        controls_class = TTSFactory.get_controls_class(engine_name)
+        if controls_class is not None:
+            descriptor = TTSFactory._registry.get(engine_name)
+            kwargs = dict(descriptor.default_kwargs) if descriptor else {}
+            return controls_class(**kwargs)
+        return EngineControlsBase()

--- a/tests/test_engine_controls.py
+++ b/tests/test_engine_controls.py
@@ -1,8 +1,16 @@
 """Tests for engine-specific control widgets."""
 
+import sys
+from unittest.mock import MagicMock
+
 import pytest
 
 pytest.importorskip("PySide6")
+
+# Mock torch before any imports trigger tts_engine_base → torch chain
+for _mod in ("torch",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
 
 from PySide6.QtCore import QCoreApplication  # noqa: E402
 
@@ -14,6 +22,75 @@ from gui.engine_controls import (  # noqa: E402
     MlxCsmControls,
     MlxKokoroControls,
 )
+from tts_factory import EngineDescriptor, TTSFactory  # noqa: E402
+
+
+class StubEngine:
+    def __init__(self, speaker_wav="", device=None, **kwargs):
+        self.speaker_wav = speaker_wav
+        self.device = device
+        self.kwargs = kwargs
+
+    def generate(self, text, **kwargs):
+        ...
+
+    def get_supported_parameters(self):
+        return []
+
+
+@pytest.fixture(autouse=True)
+def register_test_engines():
+    """Register mock engine descriptors before each test so the
+    descriptor-driven EngineControlsFactory can resolve controls_class."""
+    TTSFactory._registry.clear()
+    TTSFactory.register(
+        EngineDescriptor(
+            name="coqui",
+            engine_class=StubEngine,
+            display_name="Coqui XTTS v2",
+            requires_reference_audio=True,
+            controls_class=CoquiControls,
+        )
+    )
+    TTSFactory.register(
+        EngineDescriptor(
+            name="chatterbox-turbo",
+            engine_class=StubEngine,
+            display_name="Chatterbox Turbo (350M)",
+            default_kwargs={"variant": "turbo"},
+            controls_class=ChatterboxControls,
+        )
+    )
+    TTSFactory.register(
+        EngineDescriptor(
+            name="chatterbox-standard",
+            engine_class=StubEngine,
+            display_name="Chatterbox Standard (500M)",
+            default_kwargs={"variant": "standard"},
+            controls_class=ChatterboxControls,
+        )
+    )
+    TTSFactory.register(
+        EngineDescriptor(
+            name="mlx-kokoro",
+            engine_class=StubEngine,
+            display_name="MLX Kokoro (Preset Voices)",
+            requires_reference_audio=False,
+            supports_preset_voices=True,
+            controls_class=MlxKokoroControls,
+        )
+    )
+    TTSFactory.register(
+        EngineDescriptor(
+            name="mlx-csm",
+            engine_class=StubEngine,
+            display_name="MLX CSM (Voice Cloning)",
+            requires_reference_audio=True,
+            controls_class=MlxCsmControls,
+        )
+    )
+    yield
+    TTSFactory._registry.clear()
 
 
 @pytest.fixture(scope="module")
@@ -103,3 +180,29 @@ class TestKnownEngineControls:
         assert isinstance(controls, expected_type)
         params = controls.get_parameters()
         assert isinstance(params, dict)
+
+
+class TestMlxVoiceMetadata:
+    """Tests that MLX voice metadata is consolidated (single source of truth)."""
+
+    def test_voice_groups_is_engine_source(self):
+        from engines.mlx_audio_engine import KOKORO_VOICES
+        assert MlxKokoroControls.VOICE_GROUPS is KOKORO_VOICES
+
+    def test_lang_codes_is_engine_source(self):
+        from engines.mlx_audio_engine import KOKORO_LANG_CODES
+        assert MlxKokoroControls.LANG_CODES is KOKORO_LANG_CODES
+
+    def test_voice_groups_contains_expected_languages(self):
+        assert "American English" in MlxKokoroControls.VOICE_GROUPS
+        assert "British English" in MlxKokoroControls.VOICE_GROUPS
+        assert "Japanese" in MlxKokoroControls.VOICE_GROUPS
+        assert "Mandarin Chinese" in MlxKokoroControls.VOICE_GROUPS
+
+    def test_voice_groups_has_same_structure_as_engine(self):
+        from engines.mlx_audio_engine import KOKORO_VOICES
+        assert set(MlxKokoroControls.VOICE_GROUPS.keys()) == set(KOKORO_VOICES.keys())
+
+    def test_lang_codes_has_same_mapping(self):
+        from engines.mlx_audio_engine import KOKORO_LANG_CODES
+        assert MlxKokoroControls.LANG_CODES == KOKORO_LANG_CODES

--- a/tests/test_engine_controls.py
+++ b/tests/test_engine_controls.py
@@ -31,8 +31,7 @@ class StubEngine:
         self.device = device
         self.kwargs = kwargs
 
-    def generate(self, text, **kwargs):
-        ...
+    def generate(self, text, **kwargs): ...
 
     def get_supported_parameters(self):
         return []
@@ -187,10 +186,12 @@ class TestMlxVoiceMetadata:
 
     def test_voice_groups_is_engine_source(self):
         from engines.mlx_audio_engine import KOKORO_VOICES
+
         assert MlxKokoroControls.VOICE_GROUPS is KOKORO_VOICES
 
     def test_lang_codes_is_engine_source(self):
         from engines.mlx_audio_engine import KOKORO_LANG_CODES
+
         assert MlxKokoroControls.LANG_CODES is KOKORO_LANG_CODES
 
     def test_voice_groups_contains_expected_languages(self):
@@ -201,8 +202,10 @@ class TestMlxVoiceMetadata:
 
     def test_voice_groups_has_same_structure_as_engine(self):
         from engines.mlx_audio_engine import KOKORO_VOICES
+
         assert set(MlxKokoroControls.VOICE_GROUPS.keys()) == set(KOKORO_VOICES.keys())
 
     def test_lang_codes_has_same_mapping(self):
         from engines.mlx_audio_engine import KOKORO_LANG_CODES
+
         assert MlxKokoroControls.LANG_CODES == KOKORO_LANG_CODES

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -91,6 +91,6 @@ def test_no_old_references_in_key_files():
             for context in contexts:
                 if context in line:
                     # These lines should not contain 'voice-cloner'
-                    assert "voice-cloner" not in line.lower(), (
-                        f"Found 'voice-cloner' in {filename}:{i + 1}: {line.strip()}"
-                    )
+                    assert (
+                        "voice-cloner" not in line.lower()
+                    ), f"Found 'voice-cloner' in {filename}:{i + 1}: {line.strip()}"

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -91,6 +91,6 @@ def test_no_old_references_in_key_files():
             for context in contexts:
                 if context in line:
                     # These lines should not contain 'voice-cloner'
-                    assert (
-                        "voice-cloner" not in line.lower()
-                    ), f"Found 'voice-cloner' in {filename}:{i + 1}: {line.strip()}"
+                    assert "voice-cloner" not in line.lower(), (
+                        f"Found 'voice-cloner' in {filename}:{i + 1}: {line.strip()}"
+                    )

--- a/tests/test_tts_factory.py
+++ b/tests/test_tts_factory.py
@@ -186,6 +186,77 @@ class TestTTSFactoryAvailability:
             assert TTSFactory.get_default_engine() == "alpha"
 
 
+class TestEngineDescriptorControlsClass:
+    """Tests for the controls_class field on EngineDescriptor."""
+
+    def test_controls_class_defaults_to_none(self):
+        d = EngineDescriptor(name="foo", engine_class=StubEngine, display_name="Foo")
+        assert d.controls_class is None
+
+    def test_controls_class_can_be_set(self):
+        d = EngineDescriptor(
+            name="bar",
+            engine_class=StubEngine,
+            display_name="Bar",
+            controls_class=dict,
+        )
+        assert d.controls_class is dict
+
+    def test_controls_class_in_all_fields(self):
+        d = EngineDescriptor(
+            name="baz",
+            engine_class=StubEngine,
+            display_name="Baz",
+            requires_reference_audio=False,
+            supports_preset_voices=True,
+            platform_restriction="apple_silicon",
+            default_kwargs={"variant": "turbo"},
+            controls_class=list,
+        )
+        assert d.controls_class is list
+
+
+class TestTTSFactoryGetControlsClass:
+    """Tests for TTSFactory.get_controls_class()."""
+
+    def test_returns_none_for_unknown_engine(self):
+        assert TTSFactory.get_controls_class("nonexistent") is None
+
+    def test_returns_none_when_not_set(self, basic_descriptor):
+        TTSFactory.register(basic_descriptor)
+        assert TTSFactory.get_controls_class("test-engine") is None
+
+    def test_returns_controls_class(self):
+        TTSFactory.register(
+            EngineDescriptor(
+                name="with-controls",
+                engine_class=StubEngine,
+                display_name="With Controls",
+                controls_class=dict,
+            )
+        )
+        assert TTSFactory.get_controls_class("with-controls") is dict
+
+    def test_isolation_between_engines(self):
+        TTSFactory.register(
+            EngineDescriptor(
+                name="engine-a",
+                engine_class=StubEngine,
+                display_name="Engine A",
+                controls_class=dict,
+            )
+        )
+        TTSFactory.register(
+            EngineDescriptor(
+                name="engine-b",
+                engine_class=StubEngine,
+                display_name="Engine B",
+            )
+        )
+        assert TTSFactory.get_controls_class("engine-a") is dict
+        assert TTSFactory.get_controls_class("engine-b") is None
+
+
 class TestBootstrapEngines:
     def test_bootstrap_preserves_existing_registrations(self):
         TTSFactory.register(EngineDescriptor(name="pre-existing", engine_class=StubEngine, display_name="Pre"))

--- a/tts_factory.py
+++ b/tts_factory.py
@@ -17,6 +17,7 @@ class EngineDescriptor:
     supports_preset_voices: bool = False
     platform_restriction: str | None = None
     default_kwargs: dict[str, Any] = field(default_factory=dict)
+    controls_class: type | None = None
 
     def is_available_on_platform(self) -> bool:
         return not (self.platform_restriction == "apple_silicon" and not is_apple_silicon())
@@ -105,6 +106,11 @@ class TTSFactory:
         }
 
     @classmethod
+    def get_controls_class(cls, engine_name: str) -> type | None:
+        descriptor = cls._registry.get(engine_name)
+        return descriptor.controls_class if descriptor else None
+
+    @classmethod
     def get_default_engine(cls) -> str:
         available = cls.get_available_engines()
         if not available:
@@ -119,6 +125,7 @@ class TTSFactory:
 def _register_default_engines():
     try:
         from engines.coqui_engine import CoquiEngine
+        from gui.engine_controls import CoquiControls
 
         TTSFactory.register(
             EngineDescriptor(
@@ -127,6 +134,7 @@ def _register_default_engines():
                 display_name="Coqui XTTS v2",
                 requires_reference_audio=True,
                 supports_preset_voices=False,
+                controls_class=CoquiControls,
             )
         )
     except ImportError as e:
@@ -134,6 +142,7 @@ def _register_default_engines():
 
     try:
         from engines.chatterbox_engine import ChatterboxEngine
+        from gui.engine_controls import ChatterboxControls
 
         TTSFactory.register(
             EngineDescriptor(
@@ -143,6 +152,7 @@ def _register_default_engines():
                 requires_reference_audio=True,
                 supports_preset_voices=False,
                 default_kwargs={"variant": "turbo"},
+                controls_class=ChatterboxControls,
             )
         )
 
@@ -154,6 +164,7 @@ def _register_default_engines():
                 requires_reference_audio=True,
                 supports_preset_voices=False,
                 default_kwargs={"variant": "standard"},
+                controls_class=ChatterboxControls,
             )
         )
     except ImportError as e:
@@ -161,6 +172,7 @@ def _register_default_engines():
 
     try:
         from engines.mlx_audio_engine import MlxAudioEngine
+        from gui.engine_controls import MlxCsmControls, MlxKokoroControls
 
         TTSFactory.register(
             EngineDescriptor(
@@ -171,6 +183,7 @@ def _register_default_engines():
                 supports_preset_voices=True,
                 platform_restriction="apple_silicon",
                 default_kwargs={"variant": "kokoro"},
+                controls_class=MlxKokoroControls,
             )
         )
 
@@ -183,6 +196,7 @@ def _register_default_engines():
                 supports_preset_voices=False,
                 platform_restriction="apple_silicon",
                 default_kwargs={"variant": "csm"},
+                controls_class=MlxCsmControls,
             )
         )
     except ImportError as e:


### PR DESCRIPTION
Closes #14
Closes #15

## Summary
Consolidate engine controls registration into the descriptor-based system (TTSFactory/EngineDescriptor) and eliminate duplicated MLX Kokoro voice metadata between engine and GUI layers.

## Approach
- Added `controls_class` field to `EngineDescriptor` so each engine declares its GUI control widget alongside its engine class and metadata.
- Replaced `EngineControlsFactory.create()` hardcoded if/elif chain with descriptor lookup via `TTSFactory.get_controls_class()`.
- Removed duplicated `VOICE_GROUPS` / `LANG_CODES` from `MlxKokoroControls`; the class now references `KOKORO_VOICES` / `KOKORO_LANG_CODES` from `MlxAudioEngine` directly.
- Updated `_register_default_engines()` to pass `controls_class` for all five engine registrations.
- Added unit tests for the new `controls_class` field, `get_controls_class` method, and voice metadata identity checks.

## Changes
| File | Change |
|------|--------|
| `tts_factory.py` | Added `controls_class` field to `EngineDescriptor`; added `TTSFactory.get_controls_class()`; wired `controls_class` in all engine registrations |
| `gui/engine_controls.py` | Replaced hardcoded if/elif chain with descriptor lookup; removed duplicated `VOICE_GROUPS`/`LANG_CODES`; imports singletons from `mlx_audio_engine` |
| `tests/test_tts_factory.py` | 3 tests for `controls_class` defaults/setting; 4 tests for `get_controls_class` (9 new assertions) |
| `tests/test_engine_controls.py` | Added `register_test_engines` fixture; 5 identity tests for voice metadata being single source of truth (20 new assertions) |

## Test Results
```
93 passed in 0.36s
```

## Acceptance Criteria Verification

### Issue #14 — Descriptor-based controls
- [x] Adding an engine does not require a GUI factory conditional update (controlled by `controls_class` in descriptor)
- [x] Engine controls are discoverable from the same registration concept as engine metadata
- [x] Existing GUI controls continue to appear for supported engines (all test cases pass)

### Issue #15 — Deduplicated voice metadata
- [x] MLX voice options are maintained in one source of truth (`KOKORO_VOICES` in `mlx_audio_engine.py`)
- [x] The GUI and synthesis behavior expose the same voice choices (`MlxKokoroControls.VOICE_GROUPS is KOKORO_VOICES`)
- [x] A test or validation check detects mismatched voice metadata (identity checks in `TestMlxVoiceMetadata`)